### PR TITLE
CentCom Update

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -2,6 +2,41 @@
 "aa" = (
 /turf/open/space/basic,
 /area/space)
+"ab" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
+"ad" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/event_horizon,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"ah" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/cup/soda_cans/cola{
+	pixel_x = -5;
+	pixel_y = 9
+	},
+/obj/item/trash/can{
+	pixel_x = 7;
+	pixel_y = 2
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
+"ai" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/control)
 "ak" = (
 /obj/item/kirbyplants/organic/plant21,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -21,6 +56,17 @@
 /obj/machinery/light/floor,
 /turf/open/indestructible/dark,
 /area/centcom/central_command_areas/prison/cells)
+"ao" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "ap" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -28,6 +74,16 @@
 /obj/machinery/light/floor,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/ert)
+"aq" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/landmark/portal_exit{
+	id = "centcom_testchamb"
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "ar" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -83,6 +139,25 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin/storage)
+"ay" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4;
+	name = "mix to port"
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
+/obj/effect/mapping_helpers/airalarm/link{
+	chamber_id = "ordnanceburn"
+	},
+/obj/effect/mapping_helpers/airalarm/mixingchamber_access,
+/obj/effect/turf_decal/tile/green/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "az" = (
 /obj/machinery/modular_computer/preset/id/centcom{
 	dir = 1
@@ -104,6 +179,12 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"aC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/supplypod)
 "aD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -173,13 +254,28 @@
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
 "aP" = (
+/obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/trimline/green/filled/line,
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
+"aQ" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/magic/wand/door,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"aR" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "aS" = (
 /obj/item/kirbyplants/organic/plant22,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -193,6 +289,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
+"aV" = (
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "aW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -204,6 +306,12 @@
 /obj/structure/flora/tree/palm,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation/ship)
+"aY" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/magic/staff/chaos/unrestricted,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "aZ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/table/reinforced,
@@ -290,6 +398,13 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
+"bl" = (
+/obj/structure/sign/warning/biohazard/directional/west,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "bm" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -297,16 +412,21 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "bo" = (
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
+/turf/open/floor/engine/vacuum,
+/area/centcom/tdome/administration)
 "bp" = (
 /obj/item/trash/sosjerky,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"bu" = (
+/obj/machinery/jukebox/disco/indestructible,
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/iron/smooth,
+/area/centcom/tdome/administration)
 "bx" = (
 /turf/open/floor/iron/goonplaque{
 	desc = "This is a plaque commemorating the thunderdome and all those who have died at its pearly blast doors."
@@ -348,22 +468,33 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "bC" = (
-/obj/item/kirbyplants/organic/plant21,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/courtroom)
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "bD" = (
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
-"bG" = (
-/obj/machinery/computer/security{
-	dir = 8
+"bF" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
 	},
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/jukebox/disco/indestructible,
+/turf/open/floor/iron/smooth,
+/area/centcom/tdome/administration)
+"bG" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
 "bH" = (
@@ -371,17 +502,26 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/armory)
-"bJ" = (
-/obj/effect/turf_decal/siding/dark_blue/corner,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"bL" = (
-/obj/item/kirbyplants/organic/plant21,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+"bI" = (
+/obj/item/cardboard_cutout{
+	starting_cutout = "Private Security Officer"
 	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/control)
+"bJ" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark/smooth_large,
+/area/centcom/central_command_areas/supply)
+"bL" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/closed/indestructible/fakedoor{
+	name = "CentCom Warehouse"
+	},
+/area/centcom/central_command_areas/supply)
 "bM" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -408,7 +548,7 @@
 	req_access = list("cent_captain")
 	},
 /obj/machinery/firealarm/directional/west,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/red/filled/end,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "bR" = (
@@ -419,6 +559,15 @@
 /obj/effect/light_emitter/thunderdome,
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
+"bS" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "bV" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/records/medical/laptop,
@@ -447,6 +596,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"cc" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/landmark/portal_exit{
+	id = "centcom_testchamb"
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "cd" = (
 /obj/structure/sink/directional/east,
 /obj/structure/mirror/directional/west,
@@ -545,6 +706,9 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
+"cx" = (
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/supplypod)
 "cA" = (
 /obj/item/storage/box/emps{
 	pixel_x = 3;
@@ -576,6 +740,14 @@
 /obj/item/assembly/flash/handheld,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"cF" = (
+/obj/item/kirbyplants/random,
+/obj/structure/sign/warning/explosives/directional/east,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/centcom/tdome/administration)
 "cI" = (
 /obj/machinery/light/directional/north,
@@ -616,14 +788,17 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin/storage)
 "cO" = (
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/control)
 "cP" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/north,
 /turf/open/floor/plating,
 /area/centcom/central_command_areas/evacuation/ship)
+"cQ" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/vehicle/sealed/mecha/marauder/loaded,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "cR" = (
 /obj/item/kirbyplants/organic/plant10,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -642,8 +817,14 @@
 /turf/open/floor/iron/smooth_large,
 /area/centcom/central_command_areas/evacuation/ship)
 "cU" = (
-/obj/structure/sign/poster/greenscreen/directional/south,
-/turf/open/floor/greenscreen,
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4;
+	name = "port to mix"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/centcom/tdome/administration)
 "cV" = (
 /obj/effect/landmark/thunderdome/one,
@@ -682,11 +863,17 @@
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
 "da" = (
-/obj/effect/turf_decal/siding/dark_blue/corner{
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
+/area/centcom/central_command_areas/supply)
 "db" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -696,14 +883,12 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
 "dc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
-/obj/effect/turf_decal/siding/dark_blue/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/control)
 "dd" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/stripes/line{
@@ -711,6 +896,19 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin)
+"de" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/light/directional/west,
+/obj/effect/landmark/portal_exit{
+	id = "centcom_testchamb"
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "df" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -727,15 +925,10 @@
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "dh" = (
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white/side{
-	dir = 8
-	},
+/turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "di" = (
 /obj/structure/table/reinforced,
@@ -752,6 +945,12 @@
 /obj/effect/light_emitter/thunderdome,
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
+"dk" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/flora/bush/fullgrass/style_random,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/control)
 "dl" = (
 /obj/structure/rack,
 /obj/item/clothing/under/color/red,
@@ -766,6 +965,12 @@
 /obj/effect/light_emitter/thunderdome,
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
+"dm" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supplypod/loading/four)
 "dn" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -795,6 +1000,10 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"dr" = (
+/obj/machinery/portable_atmospherics/canister/tritium,
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "ds" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
@@ -809,6 +1018,14 @@
 /obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
+"du" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "dv" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -861,6 +1078,31 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
+"dA" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/control)
+"dB" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/structure/table{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/stamp/granted{
+	pixel_y = 9;
+	pixel_x = 7
+	},
+/obj/item/stamp/centcom{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "dC" = (
 /obj/item/kirbyplants/organic/plant21,
 /obj/effect/turf_decal/tile/red{
@@ -869,6 +1111,16 @@
 /obj/structure/sign/warning/secure_area/directional/south,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
+"dD" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/ferny/style_random,
+/obj/machinery/light/floor,
+/turf/open/floor/iron{
+	icon_state = "asteroid5";
+	name = "plating"
+	},
+/area/centcom/central_command_areas/courtroom)
 "dG" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks{
@@ -878,6 +1130,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
+"dH" = (
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/speedloader/strilka310/lionhunter,
+/obj/item/ammo_box/speedloader/strilka310/lionhunter,
+/obj/item/ammo_box/speedloader/strilka310/lionhunter,
+/obj/item/gun/ballistic/rifle/lionhunter,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "dI" = (
 /obj/item/kirbyplants/organic/plant21,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -908,6 +1169,41 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"dN" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/courtroom)
+"dO" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"dP" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/control)
+"dT" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/box/syndie_kit/centcom_costume,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "dU" = (
 /obj/structure/bookcase/random,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -937,12 +1233,32 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"dX" = (
+/obj/structure/sign/warning/explosives/directional/west,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"dZ" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "ea" = (
 /obj/item/flashlight/lamp,
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"eb" = (
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/magazine/m223,
+/obj/item/gun/ballistic/automatic/m90/unrestricted,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "ec" = (
 /obj/structure/railing{
 	dir = 4
@@ -953,6 +1269,27 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation/ship)
+"ed" = (
+/obj/machinery/atmos_shield_gen/active{
+	dir = 4
+	},
+/obj/structure/fans/tiny/invisible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/centcom/central_command_areas/supply)
+"ee" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/computer/shuttle/mining,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "eg" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/drinkingglasses,
@@ -963,6 +1300,15 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
+"ek" = (
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/smooth,
+/area/centcom/tdome/administration)
+"el" = (
+/obj/structure/chair,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "em" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -977,7 +1323,6 @@
 /obj/item/storage/box/silver_ids,
 /obj/structure/table/reinforced,
 /obj/machinery/newscaster/directional/north,
-/obj/structure/reagent_dispensers/wall/peppertank/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
@@ -986,6 +1331,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor,
 /area/centcom/central_command_areas/evacuation/ship)
+"er" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/control)
 "et" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/directions/engineering{
@@ -1065,15 +1417,18 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"eJ" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/magic/wand/polymorph,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "eK" = (
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/structure/flora/bush/grassy/style_random,
-/obj/structure/flora/bush/pale/style_random,
-/obj/machinery/light/directional/south,
-/turf/open/misc/asteroid,
-/area/centcom/central_command_areas/evacuation)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supplypod/loading/four)
 "eM" = (
 /obj/machinery/vending/cola,
 /obj/effect/turf_decal/delivery,
@@ -1098,6 +1453,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"eQ" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/pointy/style_random,
+/obj/machinery/light/directional/west,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
 "eR" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -1111,12 +1476,32 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
+"eT" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/directional/north,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/smooth,
+/area/centcom/tdome/administration)
+"eU" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
 "eV" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/taperecorder,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/briefing)
+"eW" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/centcom/tdome/administration)
 "eX" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -1143,6 +1528,10 @@
 /obj/effect/light_emitter/thunderdome,
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
+"fd" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/centcom/tdome/administration)
 "fe" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/item/kirbyplants/organic/plant21,
@@ -1205,9 +1594,28 @@
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
 "fm" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmos_shield_gen/active{
+	dir = 8
+	},
+/obj/structure/fans/tiny/invisible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plating,
-/area/centcom/central_command_areas/evacuation)
+/area/centcom/central_command_areas/supply)
+"fn" = (
+/obj/effect/turf_decal/trimline/red/filled/end{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/control)
+"fo" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Test Chamber"
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "fu" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/item/weldingtool/experimental,
@@ -1216,6 +1624,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin)
+"fv" = (
+/obj/machinery/portable_atmospherics/canister/pluoxium,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "fw" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
@@ -1239,11 +1654,11 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation/ship)
 "fE" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/status_display/evac/directional/north,
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
-/obj/machinery/status_display/evac/directional/north,
+/obj/structure/chair,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "fF" = (
@@ -1279,6 +1694,14 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/smooth_large,
 /area/centcom/central_command_areas/evacuation/ship)
+"fK" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/structure/closet/crate/bin,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "fM" = (
 /obj/structure/filingcabinet/medical,
 /obj/machinery/firealarm/directional/west,
@@ -1336,10 +1759,13 @@
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/grassy/style_random,
-/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
 /obj/structure/flora/bush/pointy/style_random,
-/obj/machinery/light/directional/south,
 /turf/open/floor/grass,
+/area/centcom/tdome/administration)
+"gc" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/iron,
 /area/centcom/tdome/administration)
 "gd" = (
 /obj/machinery/door/airlock/highsecurity,
@@ -1363,6 +1789,18 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
+"gg" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "gi" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -1397,6 +1835,15 @@
 /obj/item/storage/dice,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
+"go" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "gs" = (
 /obj/item/paper/pamphlet/centcom/visitor_info,
 /obj/item/paper/pamphlet/centcom/visitor_info,
@@ -1451,6 +1898,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
+"gB" = (
+/obj/structure/fans/tiny,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
+	dir = 10
+	},
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Test Chamber"
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "gC" = (
 /obj/machinery/door/window/brigdoor/right/directional/south{
 	name = "CentCom Stand";
@@ -1466,6 +1923,15 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"gF" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/generic/style_random,
+/obj/machinery/light/directional/south,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/control)
 "gH" = (
 /obj/structure/closet/secure_closet/security,
 /obj/item/storage/belt/security/full,
@@ -1503,12 +1969,23 @@
 /obj/structure/sign/warning/secure_area/directional/east,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/armory)
+"gT" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "gU" = (
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"gW" = (
+/obj/structure/table/reinforced,
+/obj/item/melee/baseball_bat/ablative,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "gX" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/lockbox/loyalty,
@@ -1537,6 +2014,22 @@
 /obj/machinery/light/floor,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"ha" = (
+/obj/item/organ/internal/butt{
+	pixel_x = 0;
+	pixel_y = 12
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side,
+/area/centcom/central_command_areas/supply)
+"hb" = (
+/obj/structure/table/reinforced,
+/obj/item/melee/baton/security/boomerang/loaded,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "hc" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -1567,6 +2060,13 @@
 /obj/effect/mapping_helpers/airlock/access/all/admin/bar,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"hh" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/vehicle/sealed/mecha/ripley{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "hi" = (
 /obj/item/storage/medkit/regular,
 /obj/structure/table,
@@ -1575,15 +2075,45 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/fore)
-"hm" = (
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/structure/flora/bush/grassy/style_random,
-/obj/structure/flora/bush/pale/style_random,
-/obj/machinery/light/directional/north,
-/turf/open/misc/asteroid,
+"hj" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
+"hk" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/structure/closet/wardrobe/cargotech,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
+"hl" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
+"hm" = (
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/control)
+"hn" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/jukebox/disco/indestructible,
+/turf/open/floor/iron/smooth,
+/area/centcom/tdome/administration)
 "ho" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -1593,6 +2123,24 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"hp" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
+"hq" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/laser/captain,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"hr" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "hv" = (
 /obj/machinery/barsign/all_access/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -1603,6 +2151,15 @@
 /obj/machinery/photocopier/gratis/prebuilt,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/briefing)
+"hy" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/generic/style_random,
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/control)
 "hz" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -1611,25 +2168,34 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/status_display/evac/directional/east,
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "hB" = (
-/obj/machinery/status_display/evac/directional/east,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
 	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
+/obj/structure/table/reinforced,
+/obj/item/defibrillator/loaded,
+/turf/open/floor/iron/white,
 /area/centcom/central_command_areas/control)
 "hD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /obj/machinery/light/floor,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"hE" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/centcom/tdome/administration)
 "hF" = (
@@ -1682,14 +2248,39 @@
 /area/centcom/tdome/observation)
 "hP" = (
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/sign/nanotrasen/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
+"hR" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/pointy/style_random,
+/obj/machinery/light/directional/east,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
+"hS" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/table,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/item/gun/ballistic/automatic/pistol/toy/riot,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
 "hT" = (
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/wood,
 /area/centcom/central_command_areas/admin)
+"hV" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "hW" = (
 /obj/structure/chair/office,
 /turf/open/floor/iron/grimy,
@@ -1710,10 +2301,27 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
+"ic" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/evacuation)
 "ie" = (
 /obj/item/soap/nanotrasen,
 /turf/open/floor/iron/white,
 /area/centcom/tdome/observation)
+"if" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/structure/sign/flag/massmeta{
+	pixel_x = 31;
+	pixel_y = 0
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "ig" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -1725,6 +2333,13 @@
 /obj/structure/bookcase/random,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"ii" = (
+/obj/machinery/portable_atmospherics/canister/freon,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/bluespace,
 /area/centcom/tdome/administration)
 "ij" = (
 /obj/machinery/atmospherics/components/tank/air,
@@ -1841,6 +2456,13 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
+"iA" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "iC" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -1894,6 +2516,12 @@
 /obj/structure/sign/nanotrasen/directional/south,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
+"iJ" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/energy_katana,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "iK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -1906,27 +2534,37 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
+"iM" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/supplypod)
 "iN" = (
 /obj/machinery/status_display/supply,
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/supply)
 "iO" = (
-/obj/effect/turf_decal/delivery,
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
+/area/centcom/central_command_areas/control)
 "iP" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/bluespace_crystal/fifty,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "iQ" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 1
-	},
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
+/area/centcom/tdome/administration)
 "iR" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
@@ -1934,12 +2572,14 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "iS" = (
-/obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
-	dir = 4
+/obj/structure/chair/sofa/bench/right{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/arrow_ccw{
+	dir = 9
 	},
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
+/area/centcom/central_command_areas/evacuation)
 "iT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -1978,6 +2618,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/centcom/central_command_areas/supply)
+"iY" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
+	},
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/control)
 "iZ" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
@@ -1994,25 +2642,42 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/courtroom)
+"jb" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/shield/roman{
+	pixel_x = 1;
+	pixel_y = 0
+	},
+/obj/item/shield/mirror{
+	pixel_x = -9;
+	pixel_y = 0
+	},
+/obj/item/shield/kite{
+	pixel_x = 10;
+	pixel_y = 0
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "jc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "XCCQMLoad2"
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
+/obj/structure/table/reinforced,
+/obj/item/nullrod/non_station,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "jd" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "XCCQMLoad2";
-	pixel_x = 6
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/machinery/light/floor,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/evacuation)
+"je" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/supply)
 "jf" = (
 /obj/machinery/light/directional/east,
@@ -2030,94 +2695,87 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "jk" = (
-/obj/machinery/door/poddoor{
-	id = "XCCQMLoaddoor2";
-	name = "Supply Dock Loading Door"
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "XCCQMLoad2"
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
+/obj/structure/table/reinforced,
+/obj/item/melee/energy/sword/saber,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "jl" = (
-/obj/structure/plasticflaps,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "XCCQMLoad2"
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/structure/sign/warning/vacuum/external/directional/north,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "jm" = (
-/obj/machinery/door/poddoor{
-	id = "XCCQMLoaddoor2";
-	name = "Supply Dock Loading Door"
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "XCCQMLoad2"
-	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "jn" = (
-/obj/effect/turf_decal/stripes/end,
-/obj/machinery/conveyor/inverted{
-	dir = 10;
-	id = "XCCQMLoad2"
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
-"jo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
-"jp" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
-"jq" = (
-/obj/item/stack/package_wrap,
-/obj/item/hand_labeler{
-	pixel_y = 13;
-	pixel_x = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/table,
-/obj/effect/turf_decal/bot,
-/obj/item/hand_labeler_refill{
-	pixel_x = -8;
-	pixel_y = 6
+/obj/effect/turf_decal/trimline/green/filled/arrow_ccw{
+	dir = 9
 	},
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
-"jr" = (
-/obj/machinery/door/airlock/external/ruin{
-	name = "Supply Shuttle"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/storage,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
-"js" = (
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
-"jt" = (
-/obj/effect/turf_decal/stripes/line{
+/area/centcom/central_command_areas/evacuation)
+"jo" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/structure/sign/flag/massmeta{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"jp" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/ferny/style_random,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/control)
+"jq" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4
+	},
+/turf/open/floor/engine/vacuum,
+/area/centcom/tdome/administration)
+"jr" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/pale/style_random,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/control)
+"js" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/landmark/portal_exit{
+	id = "centcom_testchamb"
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"jt" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
+"ju" = (
+/turf/open/floor/iron/smooth,
+/area/centcom/tdome/administration)
 "jv" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -2137,26 +2795,11 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "jy" = (
-/obj/machinery/button/door/indestructible{
-	id = "XCCQMLoaddoor";
-	name = "Loading Doors";
-	pixel_x = -27;
-	pixel_y = -5;
-	dir = 8
-	},
-/obj/machinery/button/door/indestructible{
-	id = "XCCQMLoaddoor2";
-	name = "Loading Doors";
-	pixel_x = -27;
-	pixel_y = 5;
-	dir = 8
-	},
-/obj/machinery/computer/cargo{
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
+/area/centcom/central_command_areas/supplypod/loading/three)
 "jA" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/holofloor/hyperspace,
@@ -2168,11 +2811,15 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/evacuation/ship)
 "jD" = (
-/obj/effect/turf_decal/loading_area{
+/obj/structure/fans/tiny,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Test Chamber"
+	},
+/turf/open/floor/iron/smooth,
+/area/centcom/tdome/administration)
 "jE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -2195,92 +2842,112 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "jI" = (
-/obj/machinery/door/poddoor{
-	id = "XCCQMLoaddoor";
-	name = "Supply Dock Loading Door"
-	},
-/obj/machinery/conveyor{
-	dir = 8;
+/obj/structure/railing,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/conveyor_switch{
 	id = "XCCQMLoad"
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "jJ" = (
-/obj/structure/plasticflaps,
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "XCCQMLoad"
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/table,
+/obj/effect/turf_decal/trimline/green/filled/arrow_ccw{
+	dir = 5
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/sign/warning/vacuum/external/directional/south,
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
+/area/centcom/central_command_areas/evacuation)
 "jK" = (
-/obj/machinery/door/poddoor{
-	id = "XCCQMLoaddoor";
-	name = "Supply Dock Loading Door"
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
 	},
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "XCCQMLoad"
-	},
-/obj/effect/turf_decal/stripes/line,
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "jL" = (
-/obj/effect/turf_decal/stripes/end{
-	dir = 1
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
 	},
-/obj/machinery/conveyor/inverted{
-	dir = 6;
-	id = "XCCQMLoad2"
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/caution{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "jM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "jN" = (
-/obj/structure/closet/wardrobe/cargotech,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
+/turf/cordon,
 /area/centcom/central_command_areas/supply)
 "jO" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod)
 "jP" = (
-/obj/machinery/conveyor_switch/oneway{
-	dir = 8;
-	id = "XCCQMLoad";
-	pixel_x = 6
+/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown/half/contrasted{
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
+/area/centcom/tdome/administration)
 "jQ" = (
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/wardrobe/cargotech,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/light/floor,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "jR" = (
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/iron/grimy,
 /area/centcom/tdome/administration)
+"jT" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/c4/x4,
+/obj/item/grenade/c4/x4,
+/obj/item/grenade/c4/x4,
+/obj/item/grenade/c4{
+	pixel_x = 8;
+	pixel_y = 0
+	},
+/obj/item/grenade/c4{
+	pixel_x = 8;
+	pixel_y = 0
+	},
+/obj/item/grenade/c4{
+	pixel_x = 8;
+	pixel_y = 0
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "jU" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/computer,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
+"jZ" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Test Chamber"
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "ka" = (
 /obj/effect/landmark/thunderdome/one,
 /obj/effect/turf_decal/stripes/line{
@@ -2296,6 +2963,20 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
+"kb" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/beanbag,
+/obj/item/storage/box/rubbershot,
+/obj/item/gun/ballistic/shotgun/automatic/dual_tube,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"kc" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/rglass/fifty,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "kd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/showtime{
@@ -2303,6 +2984,12 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"kg" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/centcom/tdome/administration)
 "kh" = (
 /obj/machinery/telecomms/allinone/nuclear,
@@ -2331,6 +3018,12 @@
 "km" = (
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/control)
+"kp" = (
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supplypod/loading/three)
 "kq" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -2341,8 +3034,8 @@
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/control)
 "kr" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/siding/yellow/corner{
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -2352,12 +3045,20 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
+"kt" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/magic/wand/teleport,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "ku" = (
-/obj/machinery/button/door/indestructible{
-	id = "CCcustoms1";
-	name = "CC Emergency Docks Control"
+/obj/structure/chair/sofa/bench/left{
+	dir = 8
 	},
-/turf/closed/indestructible/riveted,
+/obj/effect/turf_decal/trimline/green/filled/arrow_ccw{
+	dir = 10
+	},
+/turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "kv" = (
 /obj/item/kirbyplants/organic/plant21,
@@ -2400,6 +3101,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
+"kD" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/generic/style_random,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
 "kE" = (
 /obj/structure/chair,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -2426,11 +3134,51 @@
 /obj/item/stamp/law,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/courtroom)
+"kL" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/magic/staff/change/unrestricted,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"kN" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/mineral/diamond/fifty,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "kO" = (
 /obj/item/kirbyplants/organic/plant21,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"kP" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/structure/table{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/gun/ballistic/shotgun/toy/crossbow/riot{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/item/melee/energy/sword/holographic/green{
+	pixel_x = 14;
+	pixel_y = 6
+	},
+/obj/structure/sign/poster/official/random/directional/north,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
+"kQ" = (
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/speedloader/strilka310,
+/obj/item/ammo_box/speedloader/strilka310,
+/obj/item/ammo_box/speedloader/strilka310,
+/obj/item/gun/ballistic/rifle/boltaction/prime,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "kR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -2469,6 +3217,17 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
+"kW" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/pizzabox/infinite{
+	pixel_x = -2;
+	pixel_y = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "kX" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -2490,6 +3249,16 @@
 /obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
+"la" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/pointy/style_random,
+/obj/machinery/light/directional/north,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
 "lb" = (
 /obj/structure/table/wood,
 /obj/machinery/door/window/left/directional/south,
@@ -2520,6 +3289,11 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/courtroom)
+"lf" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
 "lg" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/chair/comfy/shuttle/tactical{
@@ -2538,18 +3312,43 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
+"lk" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
+"lm" = (
+/obj/machinery/portable_atmospherics/canister/water_vapor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "ln" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/brown/half/contrasted,
+/obj/structure/chair/sofa/bench/right{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/arrow_ccw{
+	dir = 6
+	},
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
+/area/centcom/central_command_areas/evacuation)
 "lo" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "lp" = (
-/obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/tile/brown/half/contrasted,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
+	},
+/obj/item/kirbyplants/organic/plant12,
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "lq" = (
@@ -2602,6 +3401,14 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/supplypod)
+"lC" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/doppler_array,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "lJ" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Shuttle Control Office"
@@ -2656,10 +3463,18 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
+"lQ" = (
+/obj/machinery/jukebox/disco/indestructible,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/centcom/tdome/administration)
 "lR" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "lS" = (
@@ -2697,6 +3512,32 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/courtroom)
+"lX" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"lY" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/landmark/portal_exit{
+	id = "centcom_testchamb"
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"ma" = (
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"mb" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/mineral/plasma/fifty,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "mc" = (
 /obj/effect/light_emitter/podbay,
 /turf/open/floor/iron,
@@ -2719,6 +3560,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/evacuation/ship)
+"mh" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/magic/staff/wipe,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "mi" = (
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 1
@@ -2743,11 +3590,24 @@
 /area/centcom/central_command_areas/control)
 "ml" = (
 /obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
+"mm" = (
+/obj/machinery/meter,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/general/hidden{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "mn" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom/syndicate,
@@ -2757,11 +3617,50 @@
 /obj/structure/table/wood,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/courtroom)
+"mr" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/landmark/portal_exit{
+	id = "centcom_testchamb"
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "ms" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/floor,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/ert)
+"mu" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/cup/beaker/noreact,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"mv" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/structure/chair/sofa/right/brown{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"mx" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"mz" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/generic/style_random,
+/obj/machinery/light/directional/east,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
 "mC" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/computer/operating,
@@ -2825,6 +3724,13 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/fore)
+"mM" = (
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/nanotrasen/directional/west,
+/obj/structure/bookcase/random,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/courtroom)
 "mN" = (
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
@@ -2838,6 +3744,12 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/fore)
+"mP" = (
+/obj/structure/table/reinforced,
+/obj/item/melee/baton/security/stunsword/loaded,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "mQ" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -2871,19 +3783,44 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
+"mV" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/machinery/light/small/directional/south,
+/obj/structure/sign/poster/official/random/directional/south,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
 "mW" = (
 /obj/structure/reagent_dispensers/wall/peppertank/directional/west,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
+"mX" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/vehicle/sealed/mecha/ripley/deathripley/real{
+	dir = 8
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "mY" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/courtroom)
+"mZ" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/machinery/light/directional/north,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
 "na" = (
 /obj/structure/chair{
 	dir = 8
@@ -2906,11 +3843,50 @@
 /obj/structure/sign/poster/official/enlist/directional/east,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation/ship)
+"nc" = (
+/obj/structure/table/reinforced,
+/obj/item/wrench,
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/item/analyzer,
+/obj/item/pipe_dispenser,
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"nd" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/table,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/item/gun/ballistic/automatic/toy/riot,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
 "ne" = (
 /obj/effect/turf_decal/tile/green,
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
+"nf" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
+"ng" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/mineral/uranium/fifty,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"nh" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/plastic/fifty,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "nj" = (
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
@@ -2971,6 +3947,40 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/fore)
+"ns" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/obj/item/kirbyplants/organic/plant21,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
+"nt" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/spawnergrenade/syndiesoap,
+/obj/item/grenade/spawnergrenade/manhacks,
+/obj/item/grenade/spawnergrenade/cat,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"nu" = (
+/obj/effect/turf_decal/arrows,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/control)
+"nw" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/vending/donksnack,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"nx" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/structure/table,
+/obj/item/gun/ballistic/shotgun/toy/riot,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
 "nz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/fax/admin,
@@ -2995,6 +4005,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/prison)
+"nE" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/book/granter/martial/plasma_fist/nobomb,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "nF" = (
 /obj/machinery/door/poddoor{
 	id = "thunderdomegen";
@@ -3016,6 +4032,18 @@
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
+"nH" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/laser/musket/prime,
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"nI" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "nJ" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted,
@@ -3039,7 +4067,8 @@
 "nM" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "CCsec1";
-	name = "CC Security Checkpoint Shutters"
+	name = "CC Security Checkpoint Shutters";
+	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -3048,6 +4077,18 @@
 /obj/structure/chair/office,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/control)
+"nO" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/structure/filingcabinet/white,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "nP" = (
 /obj/machinery/modular_computer/preset/id/centcom{
 	dir = 8
@@ -3055,6 +4096,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"nR" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "nS" = (
 /obj/structure/bookcase/random,
 /obj/machinery/light/directional/north,
@@ -3066,6 +4116,12 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
+"nU" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supplypod/loading/four)
 "nV" = (
 /obj/structure/chair{
 	dir = 4
@@ -3129,6 +4185,16 @@
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/centcom/central_command_areas/evacuation/ship)
+"od" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/structure/table/reinforced,
+/obj/item/market_uplink/blackmarket,
+/obj/item/stack/spacecash/c10000,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "oe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -3173,6 +4239,13 @@
 /obj/structure/mirror/directional/east,
 /turf/open/floor/iron/white,
 /area/centcom/tdome/observation)
+"oq" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "os" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -3251,6 +4324,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
+"oG" = (
+/obj/structure/sign/warning/radiation,
+/turf/closed/indestructible/riveted,
+/area/centcom/tdome/administration)
 "oH" = (
 /obj/machinery/shower/directional/east,
 /turf/open/floor/iron/white,
@@ -3365,6 +4442,13 @@
 	},
 /turf/open/floor/stone,
 /area/centcom/central_command_areas/evacuation/ship)
+"pa" = (
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/magazine/tommygunm45,
+/obj/item/gun/ballistic/automatic/tommygun,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "pb" = (
 /obj/effect/landmark/thunderdome/two,
 /obj/effect/turf_decal/stripes/line,
@@ -3393,18 +4477,19 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/supply)
 "pf" = (
-/obj/structure/table/reinforced,
-/obj/item/crowbar/red,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
+/area/centcom/central_command_areas/control)
 "pg" = (
-/obj/structure/table/reinforced,
-/obj/item/restraints/handcuffs/cable/zipties,
-/obj/item/assembly/flash/handheld,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
+/obj/effect/turf_decal/delivery,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/iron/dark/smooth_large,
+/area/centcom/central_command_areas/supply)
 "pj" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -3414,6 +4499,13 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
+"pk" = (
+/obj/machinery/portable_atmospherics/canister/antinoblium,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "pl" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -3427,10 +4519,27 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
+"pm" = (
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/centcom/tdome/administration)
+"po" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"pp" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "pr" = (
 /obj/structure/chair,
 /obj/machinery/newscaster/directional/north,
-/obj/effect/turf_decal/tile/green/half/contrasted{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -3439,6 +4548,26 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
+"pt" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/plasmaglass/fifty,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"pu" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/control)
+"pv" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "px" = (
 /obj/item/kirbyplants/organic/plant22,
 /obj/effect/turf_decal/tile/green/half/contrasted{
@@ -3453,12 +4582,28 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
+"pz" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/vending/liberationstation,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "pB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/ert)
+"pC" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot/old,
+/obj/item/gun/ballistic/shotgun/riot,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "pD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -3493,6 +4638,10 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"pK" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/iron/smooth,
+/area/centcom/tdome/administration)
 "pN" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/iron,
@@ -3679,13 +4828,14 @@
 	},
 /area/centcom/central_command_areas/control)
 "qy" = (
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/structure/flora/bush/generic/style_random,
-/turf/open/floor/grass,
-/area/centcom/central_command_areas/evacuation)
+/obj/structure/closet/secure_closet/security,
+/obj/item/storage/belt/security/full,
+/obj/item/gun/ballistic/automatic/wt550,
+/obj/item/clothing/head/helmet/swat/nanotrasen,
+/obj/item/crowbar/red,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/control)
 "qz" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -3693,35 +4843,48 @@
 /obj/structure/flora/bush/grassy/style_random,
 /obj/structure/flora/bush/flowers_pp/style_random,
 /obj/structure/flora/bush/pointy/style_random,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/grass,
-/area/centcom/central_command_areas/evacuation)
+/area/centcom/central_command_areas/control)
 "qA" = (
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/grassy/style_random,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/obj/structure/flora/bush/pointy/style_random,
-/obj/machinery/light/directional/north,
-/turf/open/floor/grass,
-/area/centcom/central_command_areas/evacuation)
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/wardrobe/cargotech,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "qB" = (
-/obj/structure/flora/bush/flowers_pp/style_random,
-/obj/structure/flora/bush/lavendergrass/style_random,
-/turf/open/floor/grass,
-/area/centcom/central_command_areas/evacuation)
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/centcom/tdome/administration)
 "qC" = (
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/machinery/light/directional/north,
-/turf/open/floor/grass,
-/area/centcom/central_command_areas/evacuation)
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supplypod/loading/two)
 "qD" = (
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/structure/flora/bush/lavendergrass/style_random,
-/turf/open/floor/grass,
-/area/centcom/central_command_areas/evacuation)
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/shutters{
+	id = "CCsec1";
+	name = "CC Security Checkpoint Shutters";
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/prison)
+"qE" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "qF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -3751,6 +4914,18 @@
 /obj/effect/mapping_helpers/airlock/access/all/admin/captain,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
+"qM" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/kirbyplants/organic/plant21,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/control)
+"qN" = (
+/obj/machinery/door/poddoor{
+	id = "testvent";
+	name = "Testing Chamber Vent"
+	},
+/turf/open/floor/engine/vacuum,
+/area/centcom/tdome/administration)
 "qO" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -3758,6 +4933,14 @@
 /obj/effect/light_emitter/thunderdome,
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
+"qP" = (
+/obj/structure/reagent_dispensers/wall/peppertank/directional/east,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/control)
 "qR" = (
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/structure/sign/nanotrasen/directional/south,
@@ -3781,19 +4964,28 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "qW" = (
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/centcom/central_command_areas/evacuation)
 "qX" = (
-/obj/structure/fluff/arc,
-/turf/open/floor/grass,
-/area/centcom/central_command_areas/evacuation)
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/ferny/style_random,
+/turf/open/floor/iron{
+	dir = 6;
+	icon_state = "asteroid8";
+	name = "sand"
+	},
+/area/centcom/central_command_areas/courtroom)
 "qY" = (
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
-/area/centcom/central_command_areas/evacuation)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/floor,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "XCCQMLoad"
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "rb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -3820,9 +5012,22 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/prison)
+"rj" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "rk" = (
 /turf/open/floor/wood,
 /area/centcom/central_command_areas/courtroom)
+"rl" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/iron/fifty,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "rm" = (
 /obj/machinery/computer/shuttle/labor,
 /obj/effect/turf_decal/stripes/line{
@@ -3842,12 +5047,35 @@
 /obj/structure/chair,
 /turf/open/floor/iron/grimy,
 /area/centcom/tdome/administration)
-"rq" = (
-/obj/machinery/light/floor,
-/obj/effect/turf_decal/tile/dark_blue/fourcorners,
-/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+"rp" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
+/area/centcom/tdome/administration)
+"rq" = (
+/obj/machinery/button/door{
+	id = "testvent";
+	name = "Testing Chamber Vent Control";
+	pixel_x = -25;
+	pixel_y = 5
+	},
+/obj/machinery/button/ignition{
+	id = "mixingsparker";
+	pixel_x = -25;
+	pixel_y = -5
+	},
+/obj/structure/table/reinforced,
+/obj/item/orion_ship,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "rr" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -3867,7 +5095,7 @@
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
+/area/centcom/central_command_areas/control)
 "ru" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
@@ -3920,6 +5148,10 @@
 	name = "sand"
 	},
 /area/centcom/central_command_areas/supply)
+"rG" = (
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "rH" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/structure/flora/bush/lavendergrass/style_random,
@@ -3971,8 +5203,11 @@
 	pixel_x = -32;
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
@@ -3994,23 +5229,30 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "rT" = (
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/grass,
-/area/centcom/central_command_areas/evacuation)
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/item/kirbyplants/organic/plant21{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "rU" = (
-/obj/structure/flora/bush/flowers_pp/style_random,
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/grass,
-/area/centcom/central_command_areas/evacuation)
+/obj/structure/table/reinforced,
+/obj/item/melee/energy/sword/surplus,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "rV" = (
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/grass,
-/area/centcom/central_command_areas/evacuation)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "XCCQMLoad"
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "rY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -4034,7 +5276,7 @@
 /obj/item/crowbar/power{
 	pixel_y = 15
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/supplypod)
 "sb" = (
 /obj/machinery/vending/snack,
@@ -4057,6 +5299,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
+"se" = (
+/obj/machinery/portable_atmospherics/canister/miasma,
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "sk" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/drinkingglasses,
@@ -4067,19 +5313,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/administration)
+"sl" = (
+/obj/machinery/portable_atmospherics/canister/hydrogen,
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "sn" = (
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Security"
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/medical,
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/control)
+/area/centcom/central_command_areas/supplypod/loading/three)
 "so" = (
 /obj/effect/landmark/thunderdome/one,
 /obj/effect/turf_decal/stripes/line{
@@ -4146,6 +5389,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation/ship)
+"sx" = (
+/obj/item/reagent_containers/cup/bottle/adminordrazine{
+	pixel_x = -1;
+	pixel_y = 8
+	},
+/obj/structure/altar,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
+"sy" = (
+/obj/machinery/portable_atmospherics/canister/nob,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "sz" = (
 /obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -4197,7 +5453,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "sK" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
@@ -4210,79 +5466,87 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/all/admin/general,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/control)
 "sN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
+/area/centcom/central_command_areas/supply)
 "sO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"sP" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_y = 7;
-	pixel_x = -4
-	},
-/obj/item/pen{
-	pixel_x = -5;
-	pixel_y = 9
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"sQ" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"sR" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"sS" = (
-/obj/structure/table,
-/obj/item/storage/belt/sheath/katana/toy{
-	pixel_y = 8
-	},
-/obj/item/toy/plush/carpplushie,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"sT" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
+"sP" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/structure/chair,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
+"sQ" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/item/kirbyplants/organic/plant22,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
+"sR" = (
+/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
+"sS" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/structure/chair,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
+"sT" = (
+/turf/open/floor/iron/dark/smooth_large,
+/area/centcom/central_command_areas/supply)
+"sU" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/book/granter/martial/spider_bite{
+	name = "spider bite scroll"
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "sV" = (
 /obj/machinery/door/poddoor/shuttledock,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
+"sW" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
+"sX" = (
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/machinery/recharge_station,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "sY" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Supplypod Loading"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/admin/storage,
 /turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
+/area/centcom/central_command_areas/control)
 "sZ" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Supplypod Loading"
@@ -4297,16 +5561,47 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"tc" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/spawnergrenade/clown,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "td" = (
 /obj/structure/sign/departments/drop,
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/ferry)
+"te" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supplypod/loading/one)
+"tf" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/vehicle/sealed/mecha/phazon{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "tg" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /obj/machinery/newscaster/directional/south,
-/obj/effect/turf_decal/tile/green/half/contrasted,
+/obj/effect/turf_decal/trimline/green/filled/line,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/control)
+"th" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "tl" = (
@@ -4383,13 +5678,23 @@
 "tA" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "CCFerry";
-	name = "CC Ferry Hangar"
+	name = "CC Ferry Hangar";
+	dir = 4
 	},
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
+"tE" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "tF" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Thunderdome Locker Room"
@@ -4421,6 +5726,16 @@
 	},
 /turf/open/floor/plating,
 /area/centcom/central_command_areas/fore)
+"tJ" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/portal/permanent/one_way{
+	name = "To Saratov";
+	id = "centcom_testchamb"
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation/ship)
 "tK" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -4446,6 +5761,12 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
+"tO" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/magic/wand/death/debug,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "tQ" = (
 /obj/item/kirbyplants/organic/plant22,
 /obj/machinery/firealarm/directional/west,
@@ -4459,24 +5780,96 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
+"tS" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/book/granter/action/spell/fireball,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "tT" = (
-/obj/effect/turf_decal/siding/dark_blue,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"tU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/chem_dispenser/fullupgrade,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
+/area/centcom/tdome/administration)
+"tU" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/iron/smooth,
+/area/centcom/tdome/administration)
 "tV" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "tW" = (
 /obj/structure/sign/poster/contraband/syndicate_recruitment/directional/north,
 /turf/open/indestructible/dark,
 /area/centcom/central_command_areas/admin)
+"tY" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/space/hardsuit,
+/obj/item/clothing/suit/space/hardsuit/ancient,
+/obj/item/clothing/suit/space/hardsuit/atmos,
+/obj/item/clothing/suit/space/hardsuit/carp,
+/obj/item/clothing/suit/space/hardsuit/clown,
+/obj/item/clothing/suit/space/hardsuit/cmo,
+/obj/item/clothing/suit/space/hardsuit/combatmedic,
+/obj/item/clothing/suit/space/hardsuit/deathsquad,
+/obj/item/clothing/suit/space/hardsuit/engine,
+/obj/item/clothing/suit/space/hardsuit/engine/elite,
+/obj/item/clothing/suit/space/hardsuit/ert,
+/obj/item/clothing/suit/space/hardsuit/ert/clown,
+/obj/item/clothing/suit/space/hardsuit/ert/engi,
+/obj/item/clothing/suit/space/hardsuit/ert/jani,
+/obj/item/clothing/suit/space/hardsuit/ert/med,
+/obj/item/clothing/suit/space/hardsuit/ert/paranormal,
+/obj/item/clothing/suit/space/hardsuit/ert/paranormal/inquisitor,
+/obj/item/clothing/suit/space/hardsuit/ert/sec,
+/obj/item/clothing/suit/space/hardsuit/mining,
+/obj/item/clothing/suit/space/hardsuit/rd,
+/obj/item/clothing/suit/space/hardsuit/security,
+/obj/item/clothing/suit/space/hardsuit/security/hos,
+/obj/item/clothing/suit/space/hardsuit/shielded/syndi,
+/obj/item/clothing/suit/space/hardsuit/shielded/wizard,
+/obj/item/clothing/suit/space/hardsuit/swat,
+/obj/item/clothing/suit/space/hardsuit/swat/captain,
+/obj/item/clothing/suit/space/hardsuit/syndi/elite,
+/obj/item/clothing/suit/space/hardsuit/syndi/elite/debug,
+/obj/item/clothing/suit/space/hardsuit/syndi/owl,
+/obj/item/clothing/suit/space/hardsuit/syndi_military,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"tZ" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/green/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"ua" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/landmark/portal_exit{
+	id = "centcom_testchamb"
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "ub" = (
 /obj/structure/sign/directions/command,
 /turf/closed/indestructible/riveted,
@@ -4496,16 +5889,27 @@
 /turf/closed/indestructible/riveted,
 /area/centcom/tdome/administration)
 "ug" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/closed/indestructible/riveted,
+/area/centcom/tdome/administration)
 "uh" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
+"ui" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/computer/operating{
+	dir = 4
+	},
+/obj/machinery/vitals_reader/directional/west,
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/control)
 "uj" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -4529,12 +5933,11 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "ul" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/siding/yellow/corner{
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
+/area/centcom/central_command_areas/supplypod/loading/two)
 "um" = (
 /obj/machinery/computer/communications{
 	dir = 1
@@ -4544,23 +5947,42 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
+"un" = (
+/obj/machinery/portable_atmospherics/canister/antinoblium,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
+"uo" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/closed/indestructible/riveted,
+/area/centcom/tdome/administration)
 "up" = (
 /obj/structure/table/wood,
 /obj/item/storage/briefcase,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
+"uq" = (
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/sunny/style_random,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
 "ur" = (
 /obj/machinery/pdapainter,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
 "us" = (
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
+/obj/structure/lattice,
+/obj/structure/sign/warning/docking/directional/south,
+/turf/open/space/basic,
+/area/space/nearstation)
 "ut" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -4574,9 +5996,16 @@
 /area/space)
 "uw" = (
 /obj/structure/chair/office,
-/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"ux" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
 "uy" = (
 /obj/machinery/computer/prisoner/management{
 	dir = 1
@@ -4597,22 +6026,32 @@
 /turf/open/space/basic,
 /area/space)
 "uA" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/dark_blue/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
+/obj/structure/table/reinforced,
+/obj/item/melee/baseball_bat/homerun,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "uB" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/structure/sign/nanotrasen/directional/south,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"uD" = (
+/obj/structure/table,
+/obj/item/raw_anomaly_core/random,
+/obj/item/raw_anomaly_core/random,
+/obj/item/raw_anomaly_core/random,
+/obj/item/raw_anomaly_core/random,
+/obj/item/raw_anomaly_core/random,
+/obj/item/raw_anomaly_core/random,
+/obj/item/raw_anomaly_core/random,
+/obj/item/raw_anomaly_core/random,
+/obj/item/raw_anomaly_core/random,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "uE" = (
 /obj/effect/light_emitter/thunderdome,
 /turf/closed/indestructible/fakeglass,
@@ -4628,14 +6067,17 @@
 /turf/open/floor/grass,
 /area/centcom/tdome/observation)
 "uG" = (
-/obj/effect/turf_decal/stripes/line{
+/mob/living/basic/carp/pet{
 	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
+"uJ" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/mineral/silver/fifty,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "uK" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -4678,6 +6120,20 @@
 /obj/machinery/light/floor,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation/ship)
+"uT" = (
+/obj/machinery/light/cold/directional/south,
+/turf/open/floor/iron/dark/smooth_large,
+/area/centcom/central_command_areas/supply)
+"uW" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/obj/structure/railing/corner/end/flip{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "uX" = (
 /obj/machinery/shower/directional/east,
 /obj/effect/turf_decal/tile/green{
@@ -4744,46 +6200,47 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "ve" = (
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 4
-	},
-/turf/open/floor/iron/white/corner,
-/area/centcom/central_command_areas/evacuation)
+/obj/structure/table/reinforced,
+/obj/item/melee/baseball_bat,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "vf" = (
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+/obj/machinery/portable_atmospherics/canister/nob,
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white/side,
-/area/centcom/central_command_areas/evacuation)
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "vg" = (
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 1
-	},
-/turf/open/floor/iron/white/corner{
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/evacuation)
+"vh" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"vj" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
+"vk" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/control)
+"vl" = (
+/obj/machinery/portable_atmospherics/canister/zauker,
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "vm" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light/directional/south,
@@ -4835,6 +6292,25 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
+"vw" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
+"vy" = (
+/obj/structure/chair/sofa/bench{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
 "vA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/directions/engineering{
@@ -4895,7 +6371,8 @@
 	},
 /obj/machinery/door/poddoor/shutters{
 	id = "CCsec4";
-	name = "CC Checkpoint 4 Shutters"
+	name = "CC Checkpoint 4 Shutters";
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
@@ -4911,37 +6388,57 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/evacuation/ship)
+"vN" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/closed/indestructible/riveted,
+/area/centcom/central_command_areas/control)
 "vP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
 /obj/machinery/door/poddoor/shutters{
 	id = "CCcustoms2";
-	name = "CC Customs 2 Shutters"
+	name = "CC Customs 2 Shutters";
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "vR" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "vS" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/arrows,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "vU" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom"
+	},
+/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = "CCcustoms1";
-	name = "CC Customs 1 Shutters"
-	},
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
+/area/centcom/central_command_areas/control)
+"vV" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/singularityhammer{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "vW" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -4955,34 +6452,32 @@
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
 "vX" = (
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
-	},
-/turf/open/floor/iron/white/side{
-	dir = 5
-	},
-/area/centcom/central_command_areas/evacuation)
-"vY" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
-"vZ" = (
-/obj/effect/turf_decal/siding/dark_blue{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
-"wa" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/siding/yellow/corner,
+"vY" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/structure/closet/wardrobe/cargotech,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
+"vZ" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
+"wa" = (
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
 "wb" = (
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
@@ -4990,6 +6485,60 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"wc" = (
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
+"we" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/turf_decal/trimline/green/filled/arrow_ccw{
+	dir = 10
+	},
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
+"wf" = (
+/obj/structure/table,
+/obj/item/assembly/igniter{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 2;
+	pixel_y = -1
+	},
+/obj/item/assembly/timer{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/assembly/timer{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/assembly/timer{
+	pixel_x = -3;
+	pixel_y = -8
+	},
+/obj/item/assembly/timer{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "wg" = (
 /obj/structure/closet/secure_closet/ert_com,
 /obj/effect/turf_decal/stripes/line,
@@ -5024,18 +6573,12 @@
 	dir = 1
 	},
 /obj/machinery/button/door/indestructible{
-	id = "CCcustoms1";
-	name = "CC Customs 1 Control";
-	pixel_x = 8;
-	pixel_y = -24
-	},
-/obj/machinery/button/door/indestructible{
 	id = "CCcustoms2";
 	name = "CC Customs 2 Control";
-	pixel_x = -8;
+	pixel_x = 0;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
 "wm" = (
@@ -5068,13 +6611,19 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
+"wu" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/machinery/nuclearbomb/beer,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
 "wv" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
 /obj/machinery/door/poddoor/shutters{
 	id = "CCFerry";
-	name = "CC Ferry Hangar"
+	name = "CC Ferry Hangar";
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
@@ -5123,7 +6672,7 @@
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
 "wG" = (
-/obj/effect/turf_decal/tile/green/half/contrasted{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -5133,30 +6682,23 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "wI" = (
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/control)
+/obj/machinery/portable_atmospherics/canister/nitrium,
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "wK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 4
+/obj/effect/turf_decal/siding{
+	dir = 2
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/control)
+"wL" = (
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"wL" = (
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white/side{
-	dir = 4
-	},
 /area/centcom/central_command_areas/evacuation)
 "wN" = (
 /obj/effect/turf_decal/siding/wood{
@@ -5172,6 +6714,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stone,
 /area/centcom/central_command_areas/evacuation/ship)
+"wQ" = (
+/obj/machinery/light/small/directional/south,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/supplypod)
 "wR" = (
 /obj/machinery/shower/directional/east,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -5190,11 +6739,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation/ship)
+"wV" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/generic/style_random,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
 "wW" = (
 /obj/structure/sign/flag/nanotrasen/directional/west,
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
+/obj/structure/sign/poster/greenscreen/directional/south,
 /turf/open/floor/greenscreen,
 /area/centcom/tdome/administration)
 "wX" = (
@@ -5207,6 +6766,20 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/centcom/central_command_areas/evacuation/ship)
+"xa" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/structure/tank_dispenser,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"xb" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/evacuation)
 "xc" = (
 /obj/machinery/door/airlock/external/ruin{
 	name = "Ferry Airlock"
@@ -5271,28 +6844,49 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
+"xn" = (
+/obj/effect/turf_decal/tile/green/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "xo" = (
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
+"xq" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/dualsaber,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "xr" = (
-/obj/structure/chair{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/grenade/chem_grenade/bioterrorfoam,
+/obj/item/grenade/chem_grenade/bioterrorfoam{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/status_display/evac/directional/west,
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 4
+/obj/item/grenade/chem_grenade/bioterrorfoam{
+	pixel_x = 8;
+	pixel_y = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
+/area/centcom/tdome/administration)
 "xt" = (
-/obj/effect/turf_decal/tile/dark_blue/fourcorners,
-/obj/effect/turf_decal/tile/dark_blue/fourcorners,
-/turf/open/floor/iron,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
+"xu" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/pale/style_random,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/control)
 "xv" = (
 /obj/machinery/door/poddoor{
 	id = "thunderdome";
@@ -5328,26 +6922,60 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "xF" = (
-/obj/machinery/status_display/evac/directional/east,
-/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/control)
+/area/centcom/central_command_areas/evacuation)
 "xG" = (
 /obj/item/kirbyplants/organic/plant21,
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"xH" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/glass/fifty,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "xI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/filingcabinet/white,
-/obj/effect/turf_decal/bot,
-/obj/machinery/status_display/evac/directional/east,
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/item/implanter/explosive_macro,
+/obj/item/implanter/explosive_macro{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/implanter/explosive_macro{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/tile/green/opposingcorners,
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
+/area/centcom/tdome/administration)
 "xN" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/centcom/central_command_areas/control)
+"xP" = (
+/obj/machinery/portable_atmospherics/canister/zauker,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
+"xQ" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/vending/medical,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "xR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -5399,14 +7027,22 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "xY" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/siding/yellow{
+/obj/structure/table/reinforced,
+/obj/item/storage/belt/grenade/full,
+/obj/item/storage/belt/grenade/full{
+	pixel_y = 3
+	},
+/obj/item/storage/belt/grenade/full{
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
+/area/centcom/tdome/administration)
 "xZ" = (
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/trimline/green/filled/corner,
+/turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "yb" = (
 /obj/item/kirbyplants/organic/plant21,
@@ -5426,6 +7062,20 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/supply)
+"yf" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/control)
+"yg" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/vehicle/sealed/mecha/marauder/mauler/loaded{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "yh" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -5466,13 +7116,26 @@
 /obj/machinery/computer/security{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
 "yp" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
+"yq" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
+/obj/item/kirbyplants/organic/plant12,
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "yr" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Briefing Room"
@@ -5481,6 +7144,20 @@
 /obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
+"ys" = (
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/experimental_cloner,
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/control)
+"yu" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/e_gun/stun,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "yx" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 8
@@ -5496,7 +7173,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "yA" = (
@@ -5508,23 +7185,40 @@
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
 "yB" = (
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/dark_blue,
-/obj/effect/turf_decal/tile/dark_blue,
-/turf/open/floor/iron/white/corner{
-	dir = 4
-	},
-/area/centcom/central_command_areas/evacuation)
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/plastitaniumglass/fifty,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "yC" = (
 /obj/structure/filingcabinet/security,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/control)
+"yD" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/wardrobe/cargotech,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
+"yF" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/showcase/wizard,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
+"yG" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/machinery/light/directional/west,
+/turf/open/floor/grass,
 /area/centcom/central_command_areas/control)
 "yH" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -5536,12 +7230,37 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation/ship)
+"yI" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/obj/machinery/status_display/evac/directional/west,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
+"yJ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/brigdoor/right/directional/south{
+	req_access = list("cent_captain");
+	name = "CentCom Customs"
+	},
+/obj/machinery/door/window/left/directional/north,
+/turf/open/floor/plating,
+/area/centcom/central_command_areas/evacuation)
 "yL" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"yN" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/structure/table,
+/obj/item/toy/gun,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
 "yO" = (
 /obj/machinery/computer/communications,
 /obj/machinery/status_display/evac/directional/north,
@@ -5556,6 +7275,21 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
+"yQ" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 8
+	},
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
@@ -5584,18 +7318,21 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
-"yV" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 8;
-	height = 8;
-	json_key = "cargo";
-	name = "CentCom";
-	shuttle_id = "cargo_away";
-	width = 20
+"yT" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
-/turf/open/space/basic,
-/area/space)
+/obj/structure/table/reinforced,
+/obj/structure/showcase/machinery/tv{
+	pixel_x = 0;
+	pixel_y = 10
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"yV" = (
+/obj/machinery/portable_atmospherics/canister/proto_nitrate,
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "yW" = (
 /obj/item/kirbyplants/organic/plant21,
 /obj/effect/turf_decal/tile/green{
@@ -5629,13 +7366,23 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
+"zd" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/floor,
+/turf/open/floor/iron/dark/smooth_large,
+/area/centcom/central_command_areas/supply)
+"ze" = (
+/obj/machinery/portable_atmospherics/canister/water_vapor,
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "zf" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/taperecorder,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
+/area/centcom/central_command_areas/control)
 "zh" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -5648,38 +7395,41 @@
 	planetary_atmos = 0
 	},
 /area/awaymission/errorroom)
+"zj" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "zk" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Infirmary"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/access/all/admin/medical,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "zl" = (
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
-/area/centcom/central_command_areas/evacuation)
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "zm" = (
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
-/turf/open/floor/iron/white/side{
+/obj/machinery/portable_atmospherics/canister/helium,
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/area/centcom/central_command_areas/evacuation)
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "zn" = (
 /obj/machinery/light/directional/north,
 /obj/structure/table/reinforced,
@@ -5688,6 +7438,12 @@
 /obj/item/clothing/mask/gas,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/supply)
+"zp" = (
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark/side{
+	dir = 9
+	},
 /area/centcom/central_command_areas/supply)
 "zr" = (
 /obj/docking_port/stationary{
@@ -5701,8 +7457,8 @@
 /turf/open/space/basic,
 /area/space)
 "zs" = (
-/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
-	dir = 8
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/two)
@@ -5746,6 +7502,24 @@
 /obj/structure/flora/bush/generic/style_random,
 /turf/open/floor/grass,
 /area/centcom/tdome/administration)
+"zB" = (
+/obj/structure/table/reinforced,
+/obj/item/mecha_ammo/missiles_srm,
+/obj/item/mecha_ammo/missiles_pep{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/obj/item/mecha_ammo/missiles_pep{
+	pixel_x = 0;
+	pixel_y = 6
+	},
+/obj/item/mecha_ammo/missiles_srm{
+	pixel_x = 0;
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "zC" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -5755,7 +7529,9 @@
 /turf/open/misc/asteroid,
 /area/centcom/central_command_areas/control)
 "zE" = (
-/obj/effect/turf_decal/tile/brown/anticorner/contrasted,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/three)
 "zF" = (
@@ -5769,19 +7545,21 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "zH" = (
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/obj/item/surgery_tray/full/advanced,
+/obj/effect/turf_decal/siding/corner,
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/control)
 "zI" = (
-/obj/structure/bed/medical/emergency,
-/obj/machinery/iv_drip,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
+/obj/effect/turf_decal/siding{
+	dir = 2
+	},
+/obj/structure/bed/medical/emergency,
+/obj/machinery/iv_drip,
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/control)
 "zJ" = (
@@ -5791,21 +7569,37 @@
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/control)
 "zK" = (
-/obj/machinery/computer/records/medical{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/corner{
+	dir = 8
+	},
+/obj/structure/chair/office/light{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/control)
+"zL" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "zM" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/two)
+"zN" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/mineral/adamantine{
+	amount = 50
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "zO" = (
 /obj/effect/landmark/thunderdome/two,
 /obj/effect/turf_decal/stripes/line{
@@ -5821,6 +7615,25 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
+"zP" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/structure/table/reinforced,
+/obj/item/station_charter/admin,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"zQ" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/pointy/style_random,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
 "zR" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -5849,8 +7662,18 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/tdome/observation)
+"zY" = (
+/obj/structure/table/reinforced,
+/obj/item/mecha_parts/mecha_equipment/generator,
+/obj/item/mecha_parts/mecha_equipment/gravcatapult,
+/obj/item/mecha_parts/mecha_equipment/drill/diamonddrill,
+/obj/item/mecha_parts/mecha_equipment/teleporter,
+/obj/item/mecha_parts/mecha_equipment/wormhole_generator,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "zZ" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/three)
 "Ab" = (
@@ -5905,6 +7728,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
+"Ak" = (
+/obj/vehicle/sealed/mecha/honker{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "An" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/green{
@@ -5920,9 +7750,11 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "Aq" = (
-/obj/structure/table/optable,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
+	},
+/obj/effect/turf_decal/siding{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/control)
@@ -5932,21 +7764,14 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "As" = (
-/obj/machinery/computer/communications{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
+/obj/effect/turf_decal/siding{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/control)
-"At" = (
-/obj/effect/turf_decal/siding/dark_blue/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "Av" = (
 /obj/item/kirbyplants/organic/plant21,
 /obj/effect/turf_decal/tile/green{
@@ -5954,6 +7779,27 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
+"Ay" = (
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/landmark/portal_exit{
+	id = "centcom_testchamb"
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"Az" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/shield/energy{
+	pixel_x = -9;
+	pixel_y = 0
+	},
+/obj/item/shield/energy/advanced,
+/obj/item/shield/energy/bananium{
+	pixel_x = 9;
+	pixel_y = 0
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "AA" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -6025,6 +7871,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"AM" = (
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "AO" = (
 /obj/machinery/computer/communications{
 	dir = 8
@@ -6032,84 +7883,117 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"AP" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/pale/style_random,
+/obj/machinery/light/small/directional/east,
+/turf/open/misc/asteroid,
+/area/centcom/central_command_areas/courtroom)
+"AS" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/centcom/tdome/administration)
 "AT" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/control)
 "AU" = (
-/obj/machinery/computer/operating{
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair/office{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/vitals_reader/directional/west,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
 "AV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"AW" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"AX" = (
-/obj/structure/table,
-/obj/item/toy/sword{
-	pixel_y = 8;
-	pixel_x = 14
-	},
-/obj/item/gun/ballistic/shotgun/toy/crossbow{
-	pixel_y = 11;
-	pixel_x = -2
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"AY" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"AZ" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
+"AW" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/structure/table,
+/obj/item/clothing/mask/facehugger/toy,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
+"AX" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
+"AY" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/item/kirbyplants/organic/plant22,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
+"AZ" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/book/granter/action/spell/forcewall,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"Ba" = (
+/obj/structure/table/reinforced,
+/obj/item/uplink/debug,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Bb" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"Bc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"Bd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark_blue/corner{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/caution{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
+/area/centcom/central_command_areas/supply)
+"Bc" = (
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"Bd" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
+"Bf" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Test Chamber"
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "Bh" = (
 /obj/machinery/processor,
 /obj/effect/turf_decal/stripes/end,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"Bi" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "Bj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -6152,6 +8036,13 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"Bt" = (
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/magazine/uzim9mm,
+/obj/item/gun/ballistic/automatic/mini_uzi,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Bu" = (
 /obj/item/kirbyplants/organic/plant21,
 /obj/machinery/status_display/evac/directional/west,
@@ -6185,23 +8076,24 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
-"BE" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/shutters{
-	id = "CCsec3";
-	name = "CC Main Access Shutters"
+"BC" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
+/obj/item/kirbyplants/organic/plant22,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/control)
-"BF" = (
-/obj/item/defibrillator/loaded,
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
+/area/centcom/central_command_areas/supply)
+"BE" = (
+/obj/machinery/portable_atmospherics/canister/proto_nitrate,
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/centcom/central_command_areas/control)
-"BG" = (
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
+"BF" = (
 /obj/item/reagent_containers/cup/bottle/epinephrine{
 	pixel_x = 6
 	},
@@ -6236,7 +8128,29 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/control)
+"BG" = (
 /obj/machinery/vitals_reader/directional/south,
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit/toxin,
+/obj/item/storage/medkit/o2{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/medkit/regular{
+	pixel_x = 1;
+	pixel_y = 10
+	},
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/control)
 "BH" = (
@@ -6245,6 +8159,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/obj/structure/railing{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
@@ -6262,6 +8179,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "BK" = (
@@ -6271,47 +8191,55 @@
 /obj/effect/light_emitter/thunderdome,
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
-"BM" = (
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Security"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"BN" = (
+"BL" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/storage/fancy/donut_box,
-/obj/machinery/door/window/brigdoor/right/directional/north{
-	name = "CentCom Customs";
-	req_access = list("cent_captain")
+/obj/item/gun/magic/staff/locker,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"BM" = (
+/obj/structure/fans/tiny/invisible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/centcom/central_command_areas/supply)
+"BN" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 4
+	},
+/obj/structure/railing/corner/end/flip{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
+/area/centcom/central_command_areas/supply)
 "BO" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/folder/red,
-/obj/item/pen/red,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
-"BP" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/brigdoor/right/directional/north{
-	name = "CentCom Customs";
-	req_access = list("cent_captain")
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/book/granter/martial/carp{
+	name = "carp scroll"
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"BP" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "BR" = (
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation/ship)
+"BS" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/titaniumglass/fifty,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "BT" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -6356,6 +8284,19 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
+"BZ" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
+"Ca" = (
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "Cb" = (
 /obj/machinery/button/door/indestructible{
 	id = "thunderdome";
@@ -6367,32 +8308,60 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/administration)
-"Cd" = (
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/structure/flora/bush/generic/style_random,
-/obj/machinery/light/directional/south,
-/turf/open/floor/grass,
-/area/centcom/central_command_areas/evacuation)
-"Cf" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
+"Cc" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supplypod/loading/three)
+"Cd" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/brigdoor/left/directional/south{
+	name = "CentCom Customs";
+	req_access = list("cent_captain")
+	},
+/obj/machinery/door/window/right/directional/north,
+/turf/open/floor/plating,
 /area/centcom/central_command_areas/evacuation)
-"Cg" = (
+"Ce" = (
+/obj/structure/flora/bush/grassy/style_random,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
+"Cf" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/structure/chair/office{
+	dir = 4
+	},
 /obj/item/cardboard_cutout{
 	starting_cutout = "Private Security Officer"
 	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
+/area/centcom/central_command_areas/control)
+"Cg" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
+/obj/structure/railing/corner/end{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
+"Ch" = (
+/obj/machinery/portable_atmospherics/canister/bz,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "Co" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -6414,6 +8383,32 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/courtroom)
+"Cr" = (
+/obj/structure/table/reinforced,
+/obj/item/mecha_parts/mecha_equipment/armor/anticcw_armor_booster,
+/obj/item/mecha_parts/mecha_equipment/armor/antiemp_armor_booster,
+/obj/item/mecha_parts/mecha_equipment/armor/antiproj_armor_booster,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"Cs" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/pointy/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
+"Ct" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/tesla_cannon,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"Cw" = (
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/centcom/tdome/administration)
 "Cx" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/handcuffs,
@@ -6456,12 +8451,18 @@
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
+/area/centcom/central_command_areas/control)
 "CF" = (
 /obj/machinery/suit_storage_unit/industrial,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/east,
 /turf/open/floor/iron/smooth_large,
 /area/centcom/central_command_areas/evacuation/ship)
+"CG" = (
+/obj/structure/table/reinforced,
+/obj/item/melee/baton/telescopic/contractor_baton,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "CH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -6506,18 +8507,52 @@
 /obj/structure/sign/nanotrasen/directional/north,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
+"CN" = (
+/obj/structure/table/reinforced,
+/obj/item/mecha_ammo/scattershot,
+/obj/item/mecha_ammo/lmg{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/obj/item/mecha_ammo/scattershot{
+	pixel_x = 0;
+	pixel_y = 6
+	},
+/obj/item/mecha_ammo/lmg{
+	pixel_x = 0;
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "CO" = (
 /obj/structure/table,
 /obj/item/paper/pamphlet/centcom/visitor_info,
 /obj/item/paper/pamphlet/centcom/visitor_info,
 /obj/item/paper/pamphlet/centcom/visitor_info,
 /obj/machinery/status_display/evac/directional/west,
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 1
-	},
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
+"CP" = (
+/obj/structure/table/reinforced,
+/obj/item/melee/energy/axe,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"CQ" = (
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"CS" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/vehicle/sealed/mecha/ripley/paddy/preset,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "CT" = (
 /obj/structure/table/reinforced,
 /obj/structure/railing{
@@ -6577,9 +8612,19 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
+"Db" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "Dg" = (
 /obj/machinery/light/floor,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/portal/permanent/one_way{
+	name = "To Saratov";
+	id = "centcom_testchamb"
+	},
+/turf/open/floor/bluespace,
 /area/centcom/central_command_areas/evacuation)
 "Dh" = (
 /obj/structure/table/reinforced,
@@ -6608,14 +8653,26 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
+"Dl" = (
+/obj/effect/turf_decal/tile/red/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/supply)
 "Dm" = (
-/obj/item/storage/medkit/regular,
 /obj/structure/table,
-/obj/machinery/status_display/evac/directional/east,
-/obj/effect/turf_decal/tile/green/anticorner/contrasted,
-/obj/machinery/light/directional/east,
+/obj/item/storage/medkit/regular,
+/obj/effect/turf_decal/trimline/green/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
+"Do" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "Dp" = (
 /obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/tile/green{
@@ -6631,6 +8688,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
+"Dr" = (
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "Ds" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
@@ -6651,6 +8712,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"Dx" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "Dz" = (
 /obj/structure/rack,
 /obj/item/clothing/under/color/green,
@@ -6676,6 +8744,12 @@
 /obj/structure/sign/poster/official/nanotrasen_logo/directional/east,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation/ship)
+"DE" = (
+/obj/structure/table/reinforced,
+/obj/item/melee/baton/telescopic,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "DF" = (
 /obj/structure/sign/warning/no_smoking,
 /turf/closed/indestructible/riveted,
@@ -6727,6 +8801,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor,
 /area/centcom/central_command_areas/evacuation/ship)
+"DM" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/spellbook{
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/obj/item/dice/d20/fate{
+	pixel_x = 0;
+	pixel_y = -4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "DN" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -6734,15 +8821,53 @@
 /obj/effect/light_emitter/thunderdome,
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
-"DU" = (
-/obj/item/kirbyplants/organic/plant21,
-/obj/effect/turf_decal/stripes/line,
+"DO" = (
+/obj/effect/turf_decal/trimline/red/filled/end{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/control)
+"DS" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/e_gun/hos,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"DT" = (
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/door/poddoor/shutters{
+	id = "CCcustoms2";
+	name = "CC Customs 2 Shutters";
+	dir = 4
+	},
 /turf/open/floor/iron,
+/area/centcom/central_command_areas/control)
+"DU" = (
+/obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/portal/permanent/one_way{
+	name = "To Saratov";
+	id = "centcom_testchamb"
+	},
+/turf/open/floor/bluespace,
 /area/centcom/central_command_areas/evacuation)
+"DV" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/control)
 "DW" = (
 /obj/machinery/newscaster,
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/armory)
+"DZ" = (
+/obj/machinery/portable_atmospherics/canister/nitrium,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "Eb" = (
 /obj/item/kirbyplants/organic/plant21,
 /obj/structure/extinguisher_cabinet/directional/south,
@@ -6767,6 +8892,22 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
+"Eh" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/structure/sign/warning/explosives/alt/directional/south,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"Ei" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/north,
+/obj/structure/sign/poster/official/random/directional/north,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
 "Ej" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/medkit/regular,
@@ -6808,6 +8949,12 @@
 /obj/item/kirbyplants,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation/ship)
+"Es" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/magic/staff/spellblade,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Ev" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/bodycontainer/morgue{
@@ -6816,6 +8963,12 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/evacuation/ship)
+"Ew" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/magic/staff/flying,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Ex" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/item/kirbyplants/organic/plant22,
@@ -6823,7 +8976,7 @@
 /area/centcom/central_command_areas/courtroom)
 "Ey" = (
 /obj/item/kirbyplants/organic/plant21,
-/obj/effect/turf_decal/tile/green/half/contrasted{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -6836,14 +8989,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "EA" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -6867,10 +9013,14 @@
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
 "EE" = (
-/obj/effect/turf_decal/delivery,
 /obj/effect/light_emitter/podbay,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/four)
+"EG" = (
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supplypod/loading/one)
 "EH" = (
 /obj/machinery/door/window/left/directional/west,
 /obj/effect/turf_decal/siding/wood{
@@ -6897,10 +9047,10 @@
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "EK" = (
-/obj/machinery/status_display/evac/directional/south,
-/obj/effect/turf_decal/tile/brown/half/contrasted,
+/obj/structure/table/reinforced,
+/obj/item/storage/part_replacer/bluespace/tier5,
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
+/area/centcom/tdome/administration)
 "EL" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 4
@@ -6914,10 +9064,21 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation/ship)
 "EM" = (
-/obj/effect/turf_decal/delivery,
 /obj/effect/light_emitter/podbay,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/one)
+"EP" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/ferny/style_random,
+/obj/machinery/light/floor,
+/turf/open/floor/iron{
+	dir = 6;
+	icon_state = "asteroid8";
+	name = "sand"
+	},
+/area/centcom/central_command_areas/courtroom)
 "ER" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/door/airlock/centcom{
@@ -6941,7 +9102,7 @@
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/evacuation/ship)
 "EZ" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -6960,8 +9121,8 @@
 "Fg" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/status_display/evac/directional/west,
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 8
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
@@ -6987,11 +9148,15 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "Fm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/filingcabinet/white,
-/obj/effect/turf_decal/bot,
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/mineral/titanium/fifty,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"Fn" = (
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
+/area/centcom/central_command_areas/supplypod/loading/two)
 "Fo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/directions/engineering{
@@ -7001,6 +9166,12 @@
 	},
 /turf/open/floor/plating,
 /area/centcom/central_command_areas/prison)
+"Fp" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/magic/wand/resurrection/debug,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Fq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -7008,6 +9179,15 @@
 /obj/structure/sign/warning/secure_area/directional/west,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
+"Fr" = (
+/obj/item/stack/sheet/mineral/bananium{
+	amount = 50
+	},
+/obj/structure/table/reinforced/titaniumglass,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/floor,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Fs" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "CCsec1";
@@ -7049,6 +9229,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"FA" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/control)
 "FB" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/syringes,
@@ -7059,6 +9246,12 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
+"FD" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/supply)
 "FI" = (
 /obj/effect/landmark/thunderdome/two,
 /obj/effect/turf_decal/stripes/line{
@@ -7089,10 +9282,22 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
+"FQ" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/centcom/central_command_areas/supply)
 "FR" = (
 /obj/effect/light_emitter/podbay,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/pod_storage)
+"FT" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/directional/south,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/smooth,
+/area/centcom/tdome/administration)
 "FU" = (
 /turf/closed/indestructible/fakedoor{
 	name = "Thunderdome Admin"
@@ -7129,6 +9334,12 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
+"Gh" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/mineral/gold/fifty,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Gi" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/rack,
@@ -7152,12 +9363,9 @@
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/evacuation/ship)
 "Gl" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/green/opposingcorners,
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
+/area/centcom/tdome/administration)
 "Gm" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -7175,6 +9383,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"Go" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
 "Gs" = (
 /obj/machinery/power/smes/magical,
 /obj/effect/turf_decal/stripes/line,
@@ -7183,12 +9397,48 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin/storage)
+"Gt" = (
+/obj/structure/table/reinforced,
+/obj/item/melee/energy/sword/pirate,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"Gv" = (
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/centcom/central_command_areas/supply)
+"Gw" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "Gy" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
+/obj/structure/sign/poster/greenscreen/directional/south,
 /turf/open/floor/greenscreen,
 /area/centcom/tdome/administration)
+"Gz" = (
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/supplypod)
+"GA" = (
+/obj/structure/chair/sofa/bench/left{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/arrow_ccw{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
 "GB" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/turf_decal/stripes/line,
@@ -7224,11 +9474,37 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "GD" = (
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 10
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/bronze,
+/turf/open/space/basic,
+/area/space/nearstation)
+"GF" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/generic/style_random,
+/obj/machinery/light/directional/south,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
+"GG" = (
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
+/obj/structure/table/reinforced,
+/obj/machinery/computer/records/medical/laptop{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/control)
+"GH" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/generic/style_random,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
 "GI" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
@@ -7237,14 +9513,33 @@
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
 "GJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/directions/engineering{
-	desc = "A sign that shows there are doors here. There are doors everywhere!";
-	icon_state = "doors";
-	name = "WARNING: BLAST DOORS"
+/obj/item/kirbyplants/organic/plant21,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/centcom/central_command_areas/evacuation)
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/control)
+"GK" = (
+/obj/item/assembly/signaler{
+	pixel_y = 8
+	},
+/obj/item/assembly/signaler{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/assembly/signaler{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/assembly/signaler{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "GL" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/line{
@@ -7262,12 +9557,34 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"GS" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/antigravity{
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/obj/item/grenade/antigravity{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/grenade/antigravity{
+	pixel_x = 9;
+	pixel_y = 9
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "GT" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
+"GW" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/evacuation)
 "GX" = (
 /obj/item/kirbyplants/organic/plant22,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -7289,12 +9606,27 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/smooth_edge,
 /area/centcom/central_command_areas/evacuation/ship)
+"Hc" = (
+/obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/portal/permanent/one_way{
+	name = "To Saratov";
+	id = "centcom_testchamb"
+	},
+/obj/structure/sign/poster/official/random/directional/north,
+/turf/open/floor/bluespace,
+/area/centcom/central_command_areas/evacuation)
 "He" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/floor,
 /obj/structure/sign/nanotrasen/directional/south,
 /turf/open/indestructible/dark,
 /area/centcom/central_command_areas/prison/cells)
+"Hf" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/structure/table,
+/obj/item/gun/ballistic/automatic/l6_saw/toy/unrestricted/riot,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
 "Hi" = (
 /obj/effect/turf_decal/tile/green,
 /obj/machinery/light/directional/south,
@@ -7308,6 +9640,15 @@
 /obj/structure/sign/nanotrasen/directional/north,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"Hk" = (
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
 "Hl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 8
@@ -7336,6 +9677,13 @@
 /obj/effect/mapping_helpers/airlock/access/all/admin/captain,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
+"Hq" = (
+/obj/structure/tank_dispenser,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "Hs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -7343,6 +9691,11 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
+"Hu" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/vehicle/sealed/mecha/savannah_ivanov,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Hv" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/courtroom)
@@ -7351,6 +9704,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
+"Hy" = (
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/centcom/tdome/administration)
 "Hz" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -7377,9 +9739,12 @@
 /turf/open/floor/catwalk_floor,
 /area/centcom/central_command_areas/evacuation/ship)
 "HH" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
+/area/centcom/central_command_areas/control)
 "HI" = (
 /obj/machinery/recharger{
 	pixel_y = 4
@@ -7416,6 +9781,18 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
+"HN" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/bot,
+/obj/structure/filingcabinet/white,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "HR" = (
 /obj/structure/bed/medical/emergency,
 /obj/machinery/iv_drip,
@@ -7430,6 +9807,26 @@
 /obj/structure/sign/warning/secure_area/directional/east,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
+"HT" = (
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/magazine/sniper_rounds/incendiary,
+/obj/item/ammo_box/magazine/sniper_rounds,
+/obj/item/ammo_box/magazine/sniper_rounds/penetrator,
+/obj/item/ammo_box/magazine/sniper_rounds/disruptor,
+/obj/item/ammo_box/magazine/sniper_rounds/marksman,
+/obj/item/gun/ballistic/rifle/sniper_rifle,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"HU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "HV" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/closet/secure_closet/quartermaster,
@@ -7484,6 +9881,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation/ship)
+"Ia" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/chair/office,
+/obj/item/cardboard_cutout{
+	starting_cutout = "Private Security Officer"
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/control)
 "Ic" = (
 /obj/machinery/door/poddoor{
 	id = "thunderdomehea";
@@ -7512,10 +9917,12 @@
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
 "Ie" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/siding/yellow,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
+/area/centcom/tdome/administration)
 "If" = (
 /obj/machinery/newscaster{
 	pixel_x = -32;
@@ -7526,19 +9933,35 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
+"Ig" = (
+/obj/structure/table/reinforced,
+/obj/item/reactive_armor_shell,
+/obj/item/reactive_armor_shell,
+/obj/item/reactive_armor_shell,
+/obj/item/reactive_armor_shell,
+/obj/item/reactive_armor_shell,
+/obj/item/reactive_armor_shell,
+/obj/item/reactive_armor_shell,
+/obj/item/reactive_armor_shell,
+/obj/item/reactive_armor_shell,
+/obj/item/reactive_armor_shell,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"Ij" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/wood,
+/obj/item/storage/box{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/obj/item/storage/backpack/satchel/leather,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/courtroom)
 "Im" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/control)
+/obj/machinery/portable_atmospherics/canister/plasma,
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "Io" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -7567,6 +9990,23 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
+"Is" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit/fire,
+/obj/item/storage/medkit/brute{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/control)
+"It" = (
+/obj/structure/sign/warning/directional/west,
+/turf/open/space/basic,
+/area/space)
 "Iv" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -7582,11 +10022,49 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"Iy" = (
+/obj/structure/table/reinforced,
+/obj/item/uplink/clownop,
+/obj/item/stack/telecrystal/twenty,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"IB" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/magic/wand/fireball,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"IC" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/pale/style_random,
+/turf/open/misc/asteroid,
+/area/centcom/central_command_areas/courtroom)
+"ID" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "IF" = (
 /turf/closed/indestructible/fakedoor{
 	name = "CentCom Cell"
 	},
 /area/centcom/central_command_areas/prison/cells)
+"IG" = (
+/obj/machinery/portable_atmospherics/canister/bz,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "IK" = (
 /obj/structure/closet/secure_closet/ert_sec,
 /obj/effect/turf_decal/stripes/line{
@@ -7600,24 +10078,70 @@
 /obj/machinery/light/floor,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
-"IR" = (
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/structure/flora/bush/generic/style_random,
-/obj/machinery/light/directional/south,
-/turf/open/floor/grass,
+"IS" = (
+/turf/open/floor/carpet/donk,
+/area/centcom/central_command_areas/supplypod)
+"IU" = (
+/obj/machinery/portable_atmospherics/canister/freon,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/bluespace,
 /area/centcom/tdome/administration)
-"IX" = (
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 6
+"IW" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/storage/belt/sheath/katana/toy{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/obj/item/toy/plush/carpplushie{
+	pixel_x = 0;
+	pixel_y = 0
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
+"IX" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/runed_metal/fifty,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"Ja" = (
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/recharge_station,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "Jb" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/prison/cells)
+"Je" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/structure/table{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/pen/fourcolor{
+	pixel_x = 8;
+	pixel_y = 11
+	},
+/obj/item/papercutter{
+	pixel_y = 7;
+	pixel_x = 4
+	},
+/obj/item/pen/blue{
+	pixel_x = 7;
+	pixel_y = 2
+	},
+/obj/item/pen/red{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "Jg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -7625,11 +10149,37 @@
 "Ji" = (
 /turf/open/floor/circuit/green,
 /area/centcom/tdome/arena)
+"Jj" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/centcom/tdome/administration)
+"Jk" = (
+/obj/machinery/portable_atmospherics/canister/pluoxium,
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "Jl" = (
 /obj/item/kirbyplants/organic/plant21,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"Jo" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
+"Jp" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/photocopier/gratis/prebuilt,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "Jq" = (
 /obj/effect/light_emitter/thunderdome,
 /obj/machinery/camera/motion/thunderdome{
@@ -7637,6 +10187,27 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
+"Ju" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/laser/cybersun/unrestricted,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"Jx" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/mineral/metal_hydrogen{
+	amount = 50
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"JB" = (
+/obj/machinery/portable_atmospherics/canister/miasma,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "JC" = (
 /obj/machinery/modular_computer/preset/command{
 	dir = 8
@@ -7645,6 +10216,26 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
+"JD" = (
+/obj/structure/table/reinforced,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/carbine,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/flashbang,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/flashbang/clusterbang,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/breaching,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/disabler,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/ion,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/laser,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/pulse,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/taser,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/tesla,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "JE" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 4
@@ -7658,16 +10249,61 @@
 /obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation/ship)
+"JF" = (
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/speedloader/c357/phasic,
+/obj/item/ammo_box/speedloader/c357/match,
+/obj/item/ammo_box/speedloader/c357/heartseeker,
+/obj/item/gun/ballistic/revolver,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "JJ" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/administration)
+"JK" = (
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/magazine/m223,
+/obj/item/gun/ballistic/automatic/ar,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"JL" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/slugs,
+/obj/item/storage/box/breacherslug,
+/obj/item/gun/ballistic/shotgun/automatic/combat/compact,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"JM" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"JN" = (
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/control)
 "JO" = (
 /obj/machinery/modular_computer/preset/id/centcom,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
+"JP" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/control)
+"JQ" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/control)
 "JS" = (
 /obj/structure/sign/directions/command{
 	pixel_y = 10;
@@ -7684,18 +10320,14 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/centcom/central_command_areas/evacuation/ship)
 "JU" = (
-/obj/structure/chair{
-	dir = 4
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
+/area/centcom/central_command_areas/supply)
 "JV" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -7710,6 +10342,39 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"JX" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
+"JZ" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/turf_decal/trimline/green/filled/arrow_ccw{
+	dir = 6
+	},
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
+"Kb" = (
+/obj/structure/table/reinforced,
+/obj/item/assembly/signaler/anomaly/bioscrambler,
+/obj/item/assembly/signaler/anomaly/bluespace,
+/obj/item/assembly/signaler/anomaly/dimensional,
+/obj/item/assembly/signaler/anomaly/ectoplasm,
+/obj/item/assembly/signaler/anomaly/flux,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"Kc" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/vehicle/sealed/mecha/gygax/dark/loaded,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Kd" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
@@ -7736,6 +10401,29 @@
 /obj/structure/chair,
 /turf/open/floor/iron/grimy,
 /area/centcom/tdome/administration)
+"Kj" = (
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/magazine/r10mm,
+/obj/item/gun/ballistic/automatic/pistol/deagle/regal,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"Kk" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/vehicle/sealed/mecha/ripley/mk2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"Kl" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/table/reinforced/titaniumglass,
+/obj/item/gun/blastcannon,
+/obj/effect/spawner/newbomb/noblium,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Ko" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -7744,23 +10432,73 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/tdome/observation)
+"Kp" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced,
+/obj/item/mod/control/pre_equipped/administrative,
+/obj/item/mod/control/pre_equipped/advanced,
+/obj/item/mod/control/pre_equipped/apocryphal,
+/obj/item/mod/control/pre_equipped/apocryphal/officer,
+/obj/item/mod/control/pre_equipped/atmospheric,
+/obj/item/mod/control/pre_equipped/chrono,
+/obj/item/mod/control/pre_equipped/civilian,
+/obj/item/mod/control/pre_equipped/corporate,
+/obj/item/mod/control/pre_equipped/cosmohonk,
+/obj/item/mod/control/pre_equipped/elite,
+/obj/item/mod/control/pre_equipped/elite/flamethrower,
+/obj/item/mod/control/pre_equipped/enchanted,
+/obj/item/mod/control/pre_equipped/engineering,
+/obj/item/mod/control/pre_equipped/infiltrator,
+/obj/item/mod/control/pre_equipped/interdyne,
+/obj/item/mod/control/pre_equipped/loader,
+/obj/item/mod/control/pre_equipped/magnate,
+/obj/item/mod/control/pre_equipped/medical,
+/obj/item/mod/control/pre_equipped/mining,
+/obj/item/mod/control/pre_equipped/ninja,
+/obj/item/mod/control/pre_equipped/nuclear,
+/obj/item/mod/control/pre_equipped/portable_suit,
+/obj/item/mod/control/pre_equipped/prototype,
+/obj/item/mod/control/pre_equipped/rescue,
+/obj/item/mod/control/pre_equipped/research,
+/obj/item/mod/control/pre_equipped/safeguard,
+/obj/item/mod/control/pre_equipped/security,
+/obj/item/mod/control/pre_equipped/responsory/chaplain,
+/obj/item/mod/control/pre_equipped/responsory/clown,
+/obj/item/mod/control/pre_equipped/responsory/commander,
+/obj/item/mod/control/pre_equipped/responsory/engineer,
+/obj/item/mod/control/pre_equipped/responsory/inquisitory/chaplain,
+/obj/item/mod/control/pre_equipped/responsory/inquisitory/commander,
+/obj/item/mod/control/pre_equipped/responsory/inquisitory/medic,
+/obj/item/mod/control/pre_equipped/responsory/inquisitory/security,
+/obj/item/mod/control/pre_equipped/responsory/inquisitory/syndie,
+/obj/item/mod/control/pre_equipped/responsory/janitor,
+/obj/item/mod/control/pre_equipped/responsory/medic,
+/obj/item/mod/control/pre_equipped/responsory/security,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Kq" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "CCsec4";
-	name = "CC Checkpoint 4 Shutters"
+	name = "CC Checkpoint 4 Shutters";
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
+"Kr" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/evacuation)
 "Ku" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/door/poddoor/shutters{
 	id = "CCcustoms2";
-	name = "CC Customs 2 Shutters"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+	name = "CC Customs 2 Shutters";
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
@@ -7778,6 +10516,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
+"Kz" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/centcom/tdome/administration)
 "KA" = (
 /obj/effect/landmark/thunderdome/two,
 /obj/effect/turf_decal/stripes/line{
@@ -7798,14 +10542,32 @@
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/courtroom)
 "KF" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/one)
+"KG" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/magic/staff/honk,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "KH" = (
 /turf/closed/wall/mineral/titanium,
 /area/centcom/central_command_areas/evacuation/ship)
+"KI" = (
+/obj/machinery/light/cold/directional/south,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
+"KJ" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "KK" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/stripes/line{
@@ -7848,6 +10610,12 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation/ship)
+"KP" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/laser/hellgun,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "KQ" = (
 /turf/open/floor/plating,
 /area/centcom/central_command_areas/evacuation/ship)
@@ -7897,6 +10665,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation/ship)
+"La" = (
+/obj/item/stack/package_wrap{
+	pixel_x = 6;
+	pixel_y = 0
+	},
+/obj/item/hand_labeler{
+	pixel_y = 10;
+	pixel_x = 6
+	},
+/obj/item/hand_labeler_refill{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "Lb" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
@@ -7934,6 +10722,12 @@
 /obj/structure/marker_beacon/burgundy,
 /turf/open/floor/catwalk_floor,
 /area/centcom/central_command_areas/evacuation/ship)
+"Lg" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
 "Li" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
@@ -7990,6 +10784,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation/ship)
+"Ls" = (
+/mob/living/simple_animal/bot/secbot/grievous/toy,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/centcom/tdome/administration)
 "Lt" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/centcom/central_command_areas/evacuation/ship)
@@ -8015,11 +10813,20 @@
 /turf/open/floor/plating,
 /area/centcom/central_command_areas/evacuation/ship)
 "Lx" = (
-/obj/effect/turf_decal/siding/dark_blue/corner{
-	dir = 4
+/obj/machinery/computer/security{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/control)
+"Ly" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/mineral/plastitanium{
+	amount = 50
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Lz" = (
 /obj/structure/railing{
 	dir = 10
@@ -8073,6 +10880,11 @@
 /obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation/ship)
+"LE" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/bookcase/random,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/courtroom)
 "LF" = (
 /obj/structure/flora/grass/jungle/b/style_3,
 /turf/open/floor/grass,
@@ -8082,15 +10894,15 @@
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation/ship)
 "LH" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "CCcustoms1";
-	name = "CC Customs 1 Shutters"
-	},
+/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom"
+	},
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
+/area/centcom/central_command_areas/control)
 "LI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -8128,6 +10940,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/evacuation/ship)
+"LO" = (
+/obj/structure/table/reinforced,
+/obj/item/melee/sabre,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "LP" = (
 /obj/effect/turf_decal/tile/neutral/full,
 /obj/effect/turf_decal/stripes/corner{
@@ -8155,6 +10973,13 @@
 /obj/structure/sign/poster/official/tactical_game_cards/directional/north,
 /turf/open/floor/carpet/red,
 /area/centcom/central_command_areas/evacuation/ship)
+"LT" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/structure/chair/sofa/left/brown{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "LU" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/computer/records/medical{
@@ -8173,12 +10998,84 @@
 /obj/structure/speaking_tile,
 /turf/closed/mineral/ash_rock,
 /area/awaymission/errorroom)
+"LY" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/vending/drugs,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"LZ" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/book/granter/martial/cqc,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"Mc" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/magic/staff/necropotence,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"Me" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/wormhole_projector/core_inserted,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Mf" = (
 /obj/effect/landmark/thunderdome/one,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/light_emitter/thunderdome,
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
+"Mg" = (
+/obj/structure/table/reinforced,
+/obj/item/mecha_ammo/incendiary{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/mecha_ammo/incendiary{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/obj/item/mecha_ammo/clusterbang{
+	pixel_x = 0;
+	pixel_y = 6
+	},
+/obj/item/mecha_ammo/flashbang{
+	pixel_x = 0;
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"Mh" = (
+/obj/item/transfer_valve{
+	pixel_x = -5
+	},
+/obj/item/transfer_valve{
+	pixel_x = -5
+	},
+/obj/item/transfer_valve,
+/obj/item/transfer_valve,
+/obj/item/transfer_valve{
+	pixel_x = 5
+	},
+/obj/item/transfer_valve{
+	pixel_x = 5
+	},
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"Mm" = (
+/obj/structure/bookcase/random,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/noticeboard/directional/south,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/courtroom)
 "Mn" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
@@ -8200,6 +11097,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"Mq" = (
+/obj/structure/table/reinforced,
+/obj/item/assembly/signaler/anomaly/grav,
+/obj/item/assembly/signaler/anomaly/hallucination,
+/obj/item/assembly/signaler/anomaly/pyro,
+/obj/item/assembly/signaler/anomaly/vortex,
+/obj/item/assembly/signaler/anomaly/weather,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Mr" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -8239,6 +11146,14 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"Mx" = (
+/obj/vehicle/sealed/mecha/durand{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/floor,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "My" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -8270,6 +11185,19 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"MG" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/chem_grenade/teargas/moustache,
+/obj/item/grenade/chem_grenade/teargas/moustache{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/grenade/chem_grenade/teargas/moustache{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "MH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 8
@@ -8286,7 +11214,7 @@
 	pixel_y = 6;
 	pixel_x = 5
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/supplypod)
 "MJ" = (
 /obj/structure/chair/office,
@@ -8310,7 +11238,20 @@
 /obj/machinery/power/shuttle_engine/large,
 /turf/open/floor/plating,
 /area/centcom/central_command_areas/evacuation/ship)
+"MN" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/pointy/style_random,
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/control)
 "MP" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
 /obj/effect/light_emitter/podbay,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/two)
@@ -8326,6 +11267,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/tdome/observation)
+"MT" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/vending/engivend,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "MU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/wood,
@@ -8349,6 +11298,29 @@
 /obj/structure/sign/nanotrasen/directional/north,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
+"MZ" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"Nb" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/vending/toyliberationstation,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"Nc" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/structure/signpost/salvation,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "Ne" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/trophy/gold_cup,
@@ -8374,15 +11346,34 @@
 	pixel_y = -8;
 	pixel_x = -10
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/supplypod)
+"Nj" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/centcom/tdome/administration)
 "Nk" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/siding/yellow{
-	dir = 1
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
+"Nl" = (
+/obj/item/gun/energy/meteorgun,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/table/reinforced/titaniumglass,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Nm" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -8399,11 +11390,17 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin/storage)
 "Np" = (
-/obj/structure/bookcase/random,
-/obj/structure/noticeboard/directional/south,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/courtroom)
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "Nq" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -8422,11 +11419,20 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
-"Nw" = (
-/obj/item/kirbyplants/organic/plant21,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
+"Nu" = (
+/obj/machinery/portable_atmospherics/canister/healium,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
+"Nv" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/automatic/gyropistol,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"Nw" = (
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "Nx" = (
@@ -8439,6 +11445,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"NB" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/vending/wallmed/directional/west,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "NC" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -8446,6 +11462,12 @@
 "NE" = (
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/pod_storage)
+"NF" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/gun/magic/staff/chaos/true_wabbajack,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "NG" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security"
@@ -8509,6 +11531,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/tdome/observation)
+"NQ" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "NR" = (
 /obj/machinery/door/poddoor{
 	id = "thunderdome";
@@ -8530,6 +11561,12 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
+"NV" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/laser/xray,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "NW" = (
 /obj/structure/bookcase/random,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -8547,6 +11584,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
+"Ob" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/supplypod)
 "Oc" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Administrative Office"
@@ -8562,6 +11605,12 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/centcom/central_command_areas/admin)
+"Oe" = (
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supplypod/loading/two)
 "Of" = (
 /obj/item/clipboard,
 /obj/item/stamp/denied{
@@ -8573,6 +11622,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
+"Og" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "Oh" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -8582,10 +11636,22 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
 "Oi" = (
-/obj/effect/turf_decal/delivery,
 /obj/machinery/light/floor,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
+"Oj" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/ferny/style_random,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/control)
+"Ok" = (
+/obj/machinery/portable_atmospherics/canister/hydrogen,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "Om" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -8598,7 +11664,9 @@
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/admin)
 "Oq" = (
-/obj/effect/turf_decal/tile/brown/anticorner/contrasted,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/two)
 "Or" = (
@@ -8609,6 +11677,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin/storage)
+"Os" = (
+/obj/effect/spawner/structure/window/reinforced/indestructible,
+/turf/open/floor/plating,
+/area/centcom/tdome/administration)
 "Ot" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -8623,6 +11695,13 @@
 /obj/effect/light_emitter/thunderdome,
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
+"Ov" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/computer/communications,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/control)
 "Ow" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible{
 	dir = 1
@@ -8635,6 +11714,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/fore)
+"Oy" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/gravity_gun,
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Oz" = (
 /obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/access/all/admin/general,
@@ -8669,7 +11755,7 @@
 	pixel_y = 5
 	},
 /obj/structure/table/wood,
-/turf/open/floor/iron/dark,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/supplypod)
 "OE" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -8699,6 +11785,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation/ship)
+"OG" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/melee/supermatter_sword,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/centcom/tdome/administration)
 "OH" = (
 /obj/machinery/computer/records/security{
 	dir = 4
@@ -8710,6 +11801,11 @@
 /obj/item/kirbyplants/organic/plant21,
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/evacuation/ship)
+"OJ" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/smooth,
+/area/centcom/tdome/administration)
 "OK" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/sign/warning/secure_area/directional/west,
@@ -8745,7 +11841,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
 "OP" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/one)
 "OQ" = (
@@ -8766,11 +11862,15 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
 "OS" = (
-/obj/structure/bookcase/random,
-/obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/courtroom)
+/turf/open/floor/plating,
+/area/centcom/central_command_areas/supply)
+"OU" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "OV" = (
 /obj/structure/sink/directional/west,
 /obj/structure/mirror/directional/east,
@@ -8810,6 +11910,12 @@
 /obj/machinery/light/directional/north,
 /turf/open/misc/asteroid,
 /area/centcom/tdome/observation)
+"Pa" = (
+/obj/structure/table/reinforced,
+/obj/item/minigunpack,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Pc" = (
 /obj/structure/fans/tiny,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -8877,7 +11983,9 @@
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/administration)
 "Pm" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/four)
 "Pn" = (
@@ -8924,8 +12032,8 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
 "Pv" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 8
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/four)
@@ -8945,6 +12053,30 @@
 /obj/item/paper/pamphlet/centcom/visitor_info,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod)
+"PA" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/chem_grenade/holy,
+/obj/item/grenade/chem_grenade/holy{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/grenade/chem_grenade/holy{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"PC" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "PD" = (
 /obj/item/kirbyplants/organic/plant21{
 	pixel_x = -3;
@@ -8970,10 +12102,9 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "PG" = (
-/obj/effect/turf_decal/tile/dark_blue/fourcorners,
-/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/obj/structure/fluff/arc,
 /obj/machinery/light/floor,
-/turf/open/floor/iron,
+/turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
 "PH" = (
 /obj/machinery/firealarm/directional/south,
@@ -8991,17 +12122,12 @@
 /turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/evacuation/ship)
 "PK" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/one)
 "PL" = (
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/structure/flora/bush/grassy/style_random,
-/obj/structure/flora/bush/pale/style_random,
-/turf/open/misc/asteroid,
-/area/centcom/central_command_areas/evacuation)
+/turf/open/floor/engine/vacuum,
+/area/centcom/tdome/administration)
 "PM" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/ert_spawn,
@@ -9009,6 +12135,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"PO" = (
+/obj/structure/sign/warning/docking/directional/north,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "PR" = (
 /obj/structure/table/wood,
 /obj/item/phone{
@@ -9062,6 +12197,13 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation/ship)
+"Qa" = (
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "Qb" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -9097,10 +12239,22 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"Qh" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/magic/staff/animate,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Qi" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"Qj" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/laser/captain/scattershot,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Qk" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door/indestructible{
@@ -9111,6 +12265,14 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"Ql" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/pale/style_random,
+/turf/open/misc/asteroid,
+/area/centcom/central_command_areas/courtroom)
 "Qm" = (
 /obj/item/clipboard,
 /obj/item/folder/red,
@@ -9124,15 +12286,50 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"Qn" = (
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/control)
 "Qo" = (
 /obj/item/kirbyplants/organic/plant21,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/administration)
 "Qp" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
 /obj/effect/light_emitter/podbay,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/one)
+"Qq" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/filingcabinet/white,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
+"Qs" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/shield/ballistic{
+	pixel_x = -8;
+	pixel_y = 0
+	},
+/obj/item/shield/riot/tele,
+/obj/item/shield/riot{
+	pixel_x = 7;
+	pixel_y = 0
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Qt" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/electrical{
@@ -9148,12 +12345,20 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
-"Qx" = (
+"Qw" = (
+/obj/structure/table/reinforced,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/banana_mortar/bombanana,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/banana_mortar,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/mousetrap_mortar,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/punching_glove,
+/obj/item/mecha_parts/mecha_equipment/weapon/honker,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/siding/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"Qx" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/iron/dark/smooth_large,
 /area/centcom/central_command_areas/supply)
 "Qy" = (
 /obj/machinery/shower/directional/west,
@@ -9191,6 +12396,20 @@
 "QC" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/tdome/observation)
+"QD" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/revolver/grenadelauncher/unrestricted,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"QG" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/surgery_tray/full/advanced,
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/control)
 "QH" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /obj/effect/turf_decal/tile/neutral/full,
@@ -9200,18 +12419,48 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation/ship)
-"QM" = (
-/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
+"QJ" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/supplypod/loading/three)
+/area/centcom/central_command_areas/supply)
+"QK" = (
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/sunny/style_random,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
+"QL" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/recharger,
+/obj/item/gun/energy/taser,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/control)
+"QM" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/plasmarglass/fifty,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "QO" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod)
+"QQ" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/mineral/mythril{
+	amount = 50
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "QR" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -9267,6 +12516,13 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin/storage)
+"QZ" = (
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/rocket,
+/obj/item/gun/ballistic/rocketlauncher/unrestricted,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Ra" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security"
@@ -9296,12 +12552,16 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
 "Rf" = (
-/obj/item/kirbyplants/organic/plant22,
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/sign/warning/explosives/directional/south,
+/obj/machinery/research/anomaly_refinery,
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 4
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"Rg" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
@@ -9375,7 +12635,7 @@
 /obj/item/storage/fancy/cigarettes/cigars/cohiba{
 	pixel_y = 6
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/supplypod)
 "Rp" = (
 /obj/machinery/computer/communications,
@@ -9389,14 +12649,18 @@
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
 "Rs" = (
-/obj/structure/closet/secure_closet/security,
-/obj/item/storage/belt/security/full,
-/obj/item/gun/ballistic/automatic/wt550,
-/obj/item/clothing/head/helmet/swat/nanotrasen,
-/obj/item/crowbar/red,
+/obj/structure/table/reinforced,
+/obj/item/storage/box/handcuffs,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
+/area/centcom/central_command_areas/control)
+"Rt" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/ferny/style_random,
+/obj/machinery/light/directional/east,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/control)
 "Rw" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -9411,16 +12675,16 @@
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
 "Ry" = (
-/obj/item/storage/medkit/fire,
-/obj/item/storage/medkit/regular{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
 /obj/machinery/vitals_reader/directional/south,
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/obj/machinery/computer/experimental_cloner{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/control)
 "RA" = (
@@ -9435,6 +12699,17 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/administration)
+"RD" = (
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/bluespace,
+/area/centcom/tdome/administration)
+"RE" = (
+/obj/effect/light_emitter/podbay,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supplypod/loading/three)
 "RF" = (
 /obj/structure/table/reinforced,
 /obj/item/crowbar/red,
@@ -9465,7 +12740,7 @@
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation/ship)
 "RL" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/effect/light_emitter/podbay,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/two)
@@ -9475,6 +12750,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/armory)
+"RN" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/pointy/style_random,
+/obj/machinery/light/directional/south,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
 "RP" = (
 /obj/structure/bookcase/random,
 /obj/machinery/status_display/evac/directional/south,
@@ -9492,6 +12777,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"RS" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/vehicle/sealed/mecha/gygax{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "RT" = (
 /obj/machinery/airalarm/directional/east,
 /obj/structure/filingcabinet/white,
@@ -9519,13 +12811,20 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
+"Sc" = (
+/obj/machinery/portable_atmospherics/canister/tritium,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "Sd" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
 "Se" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/two)
 "Sg" = (
@@ -9553,13 +12852,6 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/two)
 "Sj" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/dark_blue/corner,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "Sk" = (
@@ -9593,9 +12885,25 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
+"Sr" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
 "Su" = (
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod)
+"Sv" = (
+/obj/vehicle/sealed/mecha/odysseus{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/floor,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Sx" = (
 /obj/structure/chair{
 	dir = 1
@@ -9628,32 +12936,33 @@
 /turf/open/floor/iron/smooth_large,
 /area/centcom/central_command_areas/evacuation/ship)
 "SD" = (
-/obj/item/kirbyplants/organic/plant21,
-/obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/sign/nanotrasen/directional/west,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "SE" = (
-/obj/effect/turf_decal/delivery,
 /obj/effect/light_emitter/podbay,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/three)
 "SG" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
+/area/centcom/central_command_areas/control)
 "SH" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/supplypod)
 "SI" = (
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters{
 	id = "CCsec3";
-	name = "CC Main Access Shutters"
+	name = "CC Main Access Shutters";
+	dir = 1
 	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "SJ" = (
@@ -9670,6 +12979,9 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
+"SM" = (
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/centcom/tdome/administration)
 "SO" = (
 /obj/machinery/computer/records/security{
 	dir = 8
@@ -9692,8 +13004,8 @@
 /turf/open/floor/circuit/green,
 /area/centcom/central_command_areas/briefing)
 "SS" = (
-/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
-	dir = 8
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/one)
@@ -9704,10 +13016,43 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
+"SU" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "XCCQMLoad"
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
+"SV" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
+"SW" = (
+/obj/machinery/portable_atmospherics/canister/healium,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "SX" = (
 /obj/machinery/computer/shuttle,
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/evacuation/ship)
+"SY" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/supply)
 "Tb" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -9719,9 +13064,15 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation/ship)
 "Tc" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/two)
+"Td" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/courtroom)
 "Te" = (
 /obj/structure/closet/crate/engineering,
 /obj/item/stack/sheet/mineral/plasma{
@@ -9749,6 +13100,10 @@
 /obj/structure/sign/nanotrasen/directional/south,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/supply)
+"Ti" = (
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
+/turf/open/floor/iron/smooth,
+/area/centcom/tdome/administration)
 "Tj" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/cup/glass/bottle/whiskey{
@@ -9759,8 +13114,26 @@
 	pixel_x = -6;
 	pixel_y = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/supplypod)
+"Tk" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/uplink/nuclear/debug{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/uplink/debug{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "Tl" = (
 /obj/structure/table/wood,
 /obj/structure/plaque/static_plaque/thunderdome{
@@ -9777,6 +13150,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
 /area/centcom/central_command_areas/evacuation/ship)
+"Tn" = (
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "To" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -9797,6 +13176,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
+"Tq" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/shotgun/china_lake,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Ts" = (
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs/cable/zipties,
@@ -9836,8 +13221,8 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod)
 "Tz" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 4
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/three)
@@ -9846,6 +13231,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
+"TD" = (
+/obj/effect/spawner/random/structure/crate,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark/smooth_large,
+/area/centcom/central_command_areas/supply)
 "TE" = (
 /obj/structure/chair/comfy/brown{
 	color = "#596479";
@@ -9854,11 +13244,14 @@
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/briefing)
 "TG" = (
-/obj/item/kirbyplants/organic/plant21,
-/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark/smooth_large,
+/area/centcom/central_command_areas/supply)
+"TH" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
+/obj/machinery/light/floor,
+/turf/open/floor/iron/smooth,
+/area/centcom/tdome/administration)
 "TI" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -9881,6 +13274,21 @@
 /obj/effect/light_emitter/thunderdome,
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
+"TN" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
+"TP" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/vending/magivend,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "TS" = (
 /obj/structure/table/wood,
 /obj/item/dice/d20{
@@ -9928,6 +13336,18 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/admin)
+"TY" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/control)
+"TZ" = (
+/obj/structure/chair/sofa/right/brown{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "Ub" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible{
 	dir = 1
@@ -9937,6 +13357,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin/storage)
+"Uc" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "Ud" = (
 /obj/structure/filingcabinet/white,
 /obj/machinery/status_display/evac/directional/south,
@@ -9944,11 +13371,11 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/supply)
 "Uf" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "Uh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 8
@@ -9966,6 +13393,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
+"Uk" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/smooth,
+/area/centcom/tdome/administration)
 "Ul" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -9991,6 +13422,30 @@
 /obj/effect/light_emitter/thunderdome,
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
+"Uq" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/clipboard{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/folder/white{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/folder/yellow{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/stamp/denied{
+	pixel_x = -1;
+	pixel_y = 9
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "Ur" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/item/clothing/under/rank/civilian/curator/treasure_hunter,
@@ -10019,6 +13474,15 @@
 /obj/effect/light_emitter/thunderdome,
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
+"Uu" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
 "Uv" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/cup/bottle/multiver{
@@ -10038,6 +13502,19 @@
 "Ux" = (
 /turf/open/indestructible/dark,
 /area/centcom/central_command_areas/admin)
+"Uy" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/item/paper_bin{
+	pixel_x = 0;
+	pixel_y = 4
+	},
+/obj/item/pen,
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "Uz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -10046,18 +13523,36 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/centcom/central_command_areas/evacuation/ship)
 "UA" = (
-/obj/item/cardboard_cutout{
-	starting_cutout = "Private Security Officer"
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
+/area/centcom/central_command_areas/control)
+"UB" = (
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "UC" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
+"UE" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/structure/table/optable,
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/control)
+"UF" = (
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/magazine/m50,
+/obj/item/gun/ballistic/automatic/pistol/deagle,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "UH" = (
 /obj/machinery/light/directional/west,
 /obj/structure/closet/secure_closet/personal,
@@ -10075,6 +13570,16 @@
 /obj/structure/sign/warning/secure_area/directional/east,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin/storage)
+"UJ" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "UK" = (
 /obj/structure/closet/secure_closet/ert_med,
 /obj/machinery/wall_healer/directional/south{
@@ -10085,12 +13590,25 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
+"UL" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 5
+	},
+/area/centcom/central_command_areas/supply)
 "UM" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod)
+"UN" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/evacuation)
 "UO" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security"
@@ -10116,6 +13634,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
+/obj/structure/sign/poster/greenscreen/directional/south,
 /turf/open/floor/greenscreen,
 /area/centcom/tdome/administration)
 "UV" = (
@@ -10139,20 +13658,32 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/tdome/observation)
+"UZ" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/vending/wallmed/directional/east,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"Va" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/control)
 "Vc" = (
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
 "Vd" = (
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 4
-	},
-/turf/open/floor/iron/white/side{
-	dir = 10
-	},
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
 "Vf" = (
 /obj/item/kirbyplants/organic/plant21{
@@ -10182,8 +13713,19 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
+"Vj" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 1
+	},
+/obj/machinery/computer/cargo,
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "Vk" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -10197,9 +13739,23 @@
 /turf/open/misc/asteroid,
 /area/centcom/tdome/administration)
 "Vn" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/three)
+"Vo" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/obj/machinery/conveyor_switch{
+	id = "XCCQMLoad"
+	},
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "Vp" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -10210,7 +13766,7 @@
 /area/centcom/central_command_areas/admin)
 "Vq" = (
 /obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
 "Vr" = (
@@ -10225,6 +13781,25 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"Vt" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
+"Vu" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "Vv" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 4
@@ -10273,6 +13848,25 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"VC" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"VD" = (
+/obj/structure/table/reinforced,
+/obj/item/melee/sickly_blade,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"VE" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/magic/staff/healing/unrestricted,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "VF" = (
 /obj/machinery/computer/crew{
 	dir = 4
@@ -10285,6 +13879,27 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"VH" = (
+/obj/machinery/portable_atmospherics/canister/halon,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
+"VI" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/structure/shipping_container/station_appropriate,
+/turf/open/floor/iron/dark/smooth_large,
+/area/centcom/central_command_areas/supply)
+"VJ" = (
+/obj/structure/chair/sofa/bench{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
 "VK" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -10298,6 +13913,13 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
+"VN" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
+	dir = 5
+	},
+/turf/closed/indestructible/riveted,
+/area/centcom/tdome/administration)
 "VO" = (
 /obj/machinery/door/poddoor/ert{
 	id = "XCCertstore"
@@ -10307,9 +13929,27 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
 "VP" = (
-/obj/effect/turf_decal/tile/brown/anticorner/contrasted,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/supplypod/loading/four)
+/area/centcom/central_command_areas/supply)
+"VR" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "VT" = (
 /obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -10321,13 +13961,35 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
+"VV" = (
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"VW" = (
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/speedloader/c38/iceblox,
+/obj/item/ammo_box/speedloader/c38,
+/obj/item/ammo_box/speedloader/c38/hotshot,
+/obj/item/ammo_box/speedloader/c38/trac,
+/obj/item/gun/ballistic/revolver/nagant,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"VX" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/clusterbuster/cleaner,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "VY" = (
 /obj/machinery/computer/records/security{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
+/area/centcom/central_command_areas/control)
 "VZ" = (
 /obj/structure/closet/secure_closet/ert_med,
 /obj/effect/turf_decal/stripes/line{
@@ -10349,16 +14011,10 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "Wc" = (
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Security"
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
+/obj/item/kirbyplants/organic/plant22,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "Wd" = (
@@ -10374,15 +14030,51 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"Wg" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/mjollnir,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"Wh" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/structure/chair/sofa/left/brown{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"Wi" = (
+/turf/open/floor/fakespace,
+/area/centcom/tdome/administration)
 "Wl" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
+"Wm" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/structure/filingcabinet/white,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "Wn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
+/area/centcom/tdome/administration)
+"Wo" = (
+/obj/structure/table/reinforced,
+/obj/item/melee/baton/nunchaku,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/centcom/tdome/administration)
 "Wp" = (
 /obj/item/storage/briefcase{
@@ -10394,15 +14086,28 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
-"Ws" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/siding/yellow/corner{
+"Wq" = (
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/supply)
+/area/centcom/tdome/administration)
+"Wr" = (
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/magazine/smgm45/incen,
+/obj/item/ammo_box/magazine/smgm45/hp,
+/obj/item/ammo_box/magazine/smgm45/ap,
+/obj/item/ammo_box/magazine/smgm45,
+/obj/item/gun/ballistic/automatic/c20r/unrestricted,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"Ws" = (
+/obj/structure/sign/warning/directional/east,
+/turf/open/space/basic,
+/area/space)
 "Wt" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/four)
 "Wv" = (
@@ -10412,11 +14117,28 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
+"Ww" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/generic/style_random,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
 "Wy" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/ert_spawn,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"Wz" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/structure/chair,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
 "WE" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
@@ -10436,12 +14158,19 @@
 /obj/structure/reagent_dispensers/wall/peppertank/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
+/area/centcom/central_command_areas/control)
 "WG" = (
 /obj/structure/closet/secure_closet/ert_engi,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
+"WJ" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
+/obj/item/kirbyplants/organic/plant22,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
 "WK" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/tile/green{
@@ -10499,6 +14228,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"WQ" = (
+/obj/item/gun/energy/marksman_revolver,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/table/reinforced/titaniumglass,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "WR" = (
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
@@ -10512,6 +14249,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/admin/officer,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin)
+"WV" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "WX" = (
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/grimy,
@@ -10541,7 +14282,7 @@
 /obj/machinery/newscaster/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
+/area/centcom/central_command_areas/control)
 "Xc" = (
 /obj/structure/noticeboard/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -10558,6 +14299,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
+"Xe" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/clusterbuster/spawner_manhacks,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "Xf" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -10580,10 +14326,10 @@
 /area/centcom/central_command_areas/evacuation/ship)
 "Xk" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/box/handcuffs,
+/obj/item/crowbar/red,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
+/area/centcom/central_command_areas/control)
 "Xl" = (
 /obj/structure/sink/directional/east,
 /obj/structure/mirror/directional/west,
@@ -10612,7 +14358,9 @@
 /turf/open/floor/wood,
 /area/centcom/central_command_areas/admin)
 "Xs" = (
-/obj/effect/turf_decal/tile/brown/anticorner/contrasted,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/one)
 "Xt" = (
@@ -10632,6 +14380,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/tdome/observation)
+"Xv" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/control)
 "Xw" = (
 /turf/open/floor/iron/grimy,
 /area/centcom/tdome/administration)
@@ -10654,17 +14411,35 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/central_command_areas/admin)
+"XB" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/magic/staff/shrink,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "XC" = (
 /obj/machinery/vending/snack,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/fore)
 "XD" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/one)
+"XE" = (
+/obj/docking_port/stationary{
+	dwidth = 8;
+	height = 8;
+	json_key = "cargo";
+	name = "CentCom";
+	shuttle_id = "cargo_away";
+	width = 20;
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/centcom/central_command_areas/supply)
 "XF" = (
 /obj/machinery/door/window/brigdoor/right/directional/south{
 	name = "CentCom Stand";
@@ -10702,6 +14477,20 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
+"XN" = (
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/magazine/m12g/stun,
+/obj/item/ammo_box/magazine/m12g/slug,
+/obj/item/ammo_box/magazine/m12g/meteor,
+/obj/item/ammo_box/magazine/m12g/flechette,
+/obj/item/ammo_box/magazine/m12g/dragon,
+/obj/item/ammo_box/magazine/m12g/donk,
+/obj/item/ammo_box/magazine/m12g/bioterror,
+/obj/item/ammo_box/magazine/m12g,
+/obj/item/gun/ballistic/shotgun/bulldog,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "XQ" = (
 /obj/machinery/computer/crew{
 	dir = 1
@@ -10714,6 +14503,25 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/centcom/central_command_areas/supplypod)
+"XX" = (
+/obj/vehicle/sealed/mecha/clarke{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"XY" = (
+/obj/structure/table/reinforced,
+/obj/item/uplink/nuclear/debug,
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"XZ" = (
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "Ya" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/armory)
@@ -10728,6 +14536,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
+"Yf" = (
+/obj/machinery/portable_atmospherics/canister/halon,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "Yg" = (
 /obj/effect/landmark/thunderdome/two,
 /obj/effect/turf_decal/stripes/line{
@@ -10736,6 +14549,26 @@
 /obj/effect/light_emitter/thunderdome,
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
+"Yh" = (
+/obj/item/assembly/prox_sensor{
+	pixel_x = -4;
+	pixel_y = 1
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = 9;
+	pixel_y = -2
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_y = 2
+	},
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "Yi" = (
 /obj/machinery/computer/camera_advanced,
 /turf/open/floor/iron/dark/herringbone,
@@ -10762,6 +14595,14 @@
 "Yn" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/supplypod)
+"Yo" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
+	},
+/obj/item/kirbyplants/organic/plant22,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "Yq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -10775,12 +14616,27 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
+"Ys" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "Yt" = (
 /obj/structure/sign/directions/security{
 	dir = 1
 	},
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/armory)
+"Yv" = (
+/obj/structure/table/reinforced,
+/obj/item/melee/baton/security/loaded,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Yx" = (
 /turf/open/floor/iron/white/herringbone,
 /area/centcom/central_command_areas/evacuation/ship)
@@ -10792,6 +14648,17 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"Yz" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/light/directional/east,
+/obj/effect/landmark/portal_exit{
+	id = "centcom_testchamb"
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "YA" = (
 /obj/machinery/door/airlock/centcom{
 	locked = 1;
@@ -10800,6 +14667,27 @@
 /obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"YB" = (
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/costume/tv_head{
+	pixel_x = -17;
+	pixel_y = 0
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"YD" = (
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/magazine/m7mm/incen,
+/obj/item/ammo_box/magazine/m7mm/match,
+/obj/item/ammo_box/magazine/m7mm/hollow,
+/obj/item/ammo_box/magazine/m7mm/bouncy,
+/obj/item/ammo_box/magazine/m7mm/ap,
+/obj/item/ammo_box/magazine/m7mm,
+/obj/item/gun/ballistic/automatic/l6_saw/unrestricted,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "YG" = (
 /obj/structure/closet/emcloset,
 /obj/item/tank/internals/emergency_oxygen/engi,
@@ -10822,6 +14710,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation/ship)
+"YI" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/e_gun,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "YO" = (
 /obj/item/radio{
 	pixel_x = 5;
@@ -10886,23 +14780,39 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
 "YY" = (
-/obj/item/storage/medkit/toxin,
-/obj/item/storage/medkit/o2{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/corner{
+	dir = 1
+	},
+/obj/machinery/experimental_cloner_scanner,
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/control)
+"YZ" = (
+/obj/structure/table/reinforced,
+/obj/item/melee/energy/sword/bananium,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Za" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/sign/nanotrasen/directional/south,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
+"Zb" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/green/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"Zc" = (
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supplypod/loading/one)
 "Ze" = (
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
@@ -10911,6 +14821,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/centcom/central_command_areas/admin)
+"Zh" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/structure/cursed_slot_machine,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "Zi" = (
 /obj/effect/landmark/thunderdome/one,
 /obj/effect/turf_decal/stripes/line,
@@ -10971,6 +14891,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/tdome/observation)
+"Zn" = (
+/obj/machinery/portable_atmospherics/canister/helium,
+/turf/open/floor/iron/bluespace,
+/area/centcom/tdome/administration)
 "Zq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/herringbone,
@@ -11070,6 +14994,27 @@
 /obj/machinery/barsign/all_access/directional/north,
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/evacuation/ship)
+"ZH" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
+"ZI" = (
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/centcom/tdome/administration)
 "ZM" = (
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
@@ -11096,11 +15041,19 @@
 /turf/open/floor/grass,
 /area/centcom/tdome/observation)
 "ZQ" = (
-/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/four)
+"ZR" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/vehicle/sealed/mecha/marauder/seraph{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "ZS" = (
 /obj/structure/table/reinforced,
 /obj/item/wrench,
@@ -11109,6 +15062,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"ZU" = (
+/obj/vehicle/sealed/mecha/justice/loaded{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "ZX" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security"
@@ -11120,6 +15080,15 @@
 /obj/effect/mapping_helpers/airlock/access/all/admin/storage,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
+"ZY" = (
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/magazine/smgm9mm/fire,
+/obj/item/ammo_box/magazine/smgm9mm/ap,
+/obj/item/ammo_box/magazine/smgm9mm,
+/obj/item/gun/ballistic/automatic/proto/unrestricted,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 
 (1,1,1) = {"
 TJ
@@ -17957,47 +21926,47 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
 aa
 aa
 aa
@@ -18214,6 +22183,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -18253,8 +22223,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+jN
 aa
 aa
 aa
@@ -18471,6 +22440,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -18510,8 +22480,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+jN
 aa
 aa
 aa
@@ -18728,6 +22697,21 @@ aa
 aa
 aa
 aa
+jN
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Ws
 aa
 aa
 aa
@@ -18753,22 +22737,7 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+jN
 aa
 aa
 aa
@@ -18985,6 +22954,21 @@ aa
 aa
 aa
 aa
+jN
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+iF
 aa
 aa
 aa
@@ -19010,22 +22994,7 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+jN
 aa
 aa
 aa
@@ -19242,6 +23211,21 @@ aa
 aa
 aa
 aa
+jN
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+BP
+BP
+Bd
+iF
 aa
 aa
 aa
@@ -19267,22 +23251,7 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+jN
 aa
 aa
 aa
@@ -19499,6 +23468,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -19509,37 +23479,36 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+BP
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+jN
 aa
 aa
 aa
@@ -19756,47 +23725,47 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+BP
+GD
+BP
+BP
+BP
+us
+iF
+Yo
+aR
+vY
+vY
+vY
+Wm
+aR
+aR
+qA
+qA
+qA
+HN
+aR
+aR
+aR
+aR
+aR
+JX
+aR
+aR
+Gw
+iF
+sT
+sT
+sT
+sT
+iF
+jN
 aa
 aa
 aa
@@ -20013,6 +23982,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -20023,37 +23993,36 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+BP
+iF
+bC
+Np
+Np
+jL
+Np
+Np
+Np
+Np
+Np
+jL
+Np
+Np
+Np
+ZH
+oJ
+Vu
+jt
+jt
+jt
+tE
+kr
+iG
+sT
+sT
+sT
+sT
+iF
+jN
 aa
 aa
 aa
@@ -20270,6 +24239,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -20280,37 +24250,36 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Bd
+ed
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+VP
+oJ
+kr
+TG
+TG
+VI
+jm
+kr
+iG
+sT
+sT
+sT
+uT
+iF
+jN
 aa
 aa
 aa
@@ -20527,6 +24496,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -20537,37 +24507,36 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Bd
+BM
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+VP
+oJ
+kr
+VI
+TG
+TG
+jm
+hp
+iF
+sT
+sT
+sT
+sT
+iF
+jN
 aa
 aa
 aa
@@ -20784,6 +24753,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -20794,37 +24764,36 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Bd
+BM
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+VP
+oJ
+kr
+TG
+TG
+TG
+jm
+kr
+iF
+sT
+sT
+sT
+sT
+iF
+jN
 aa
 aa
 aa
@@ -21041,6 +25010,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -21051,37 +25021,36 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Bd
+BM
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+PC
+oJ
+kr
+TG
+VI
+TG
+jm
+kr
+iF
+sT
+sT
+sT
+sT
+iF
+jN
 aa
 aa
 aa
@@ -21298,6 +25267,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -21308,37 +25278,36 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Bd
+BM
+OS
+OS
+OS
+Gv
+OS
+OS
+OS
+OS
+OS
+OS
+Gv
+OS
+OS
+ee
+oJ
+kr
+TG
+zd
+VI
+jm
+kr
+iF
+sT
+sT
+sT
+sT
+iF
+jN
 aa
 aa
 aa
@@ -21555,6 +25524,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -21565,37 +25535,36 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Bd
+BM
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+VP
+oJ
+jK
+TG
+TG
+TG
+jm
+kr
+iF
+sT
+sT
+sT
+uT
+iF
+jN
 aa
 aa
 aa
@@ -21812,6 +25781,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -21822,6 +25792,36 @@ aa
 aa
 aa
 aa
+Bd
+BM
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+jQ
+oJ
+Je
+Qx
+TG
+TG
+jm
+hp
+iF
+sT
+sT
+sT
+sT
+iF
+jN
 aa
 aa
 aa
@@ -21859,60 +25859,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
 aa
 "}
 (43,1,1) = {"
@@ -22069,6 +26038,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -22079,6 +26049,36 @@ aa
 aa
 aa
 aa
+Bd
+BM
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+VP
+oJ
+dB
+TG
+TG
+TG
+jm
+fK
+iF
+sT
+sT
+sT
+sT
+iF
+jN
 aa
 aa
 aa
@@ -22116,60 +26116,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
 aa
 "}
 (44,1,1) = {"
@@ -22326,6 +26295,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -22336,6 +26306,36 @@ aa
 aa
 aa
 aa
+Bd
+fm
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+VP
+oJ
+kr
+bJ
+pg
+bJ
+jm
+kr
+iG
+sT
+Dl
+FQ
+sT
+iF
+jN
 aa
 aa
 aa
@@ -22373,60 +26373,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
 aa
 "}
 (45,1,1) = {"
@@ -22583,6 +26552,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -22593,6 +26563,36 @@ aa
 aa
 aa
 aa
+BP
+iF
+lp
+Nk
+yQ
+Bb
+gg
+Nk
+Nk
+Nk
+Nk
+Bb
+Nk
+Nk
+Nk
+vw
+oJ
+Vo
+VR
+VR
+VR
+uW
+kr
+iG
+Dl
+je
+UL
+oJ
+iF
+jN
 aa
 aa
 aa
@@ -22630,60 +26630,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
 aa
 "}
 (46,1,1) = {"
@@ -22840,11 +26809,47 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
 aa
 aa
+BP
+GD
+BP
+BP
+BP
+us
+iF
+PO
+oJ
+jI
+rV
+rV
+qY
+rV
+rV
+SU
+rV
+rV
+qY
+rV
+rV
+rV
+rV
+rV
+qY
+rV
+qE
+rT
+iF
+Dl
+FD
+ha
+KI
+iF
+jN
 aa
 aa
 aa
@@ -22882,65 +26887,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
 aa
 "}
 (47,1,1) = {"
@@ -23097,6 +27066,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -23107,6 +27077,36 @@ aa
 aa
 aa
 aa
+BP
+iF
+yq
+Np
+BN
+jL
+da
+Np
+Np
+Np
+Np
+jL
+Np
+Np
+Np
+ZH
+oJ
+Vu
+Vt
+Vt
+Vt
+Cg
+kr
+iG
+Dl
+SY
+zp
+oJ
+iF
+jN
 aa
 aa
 aa
@@ -23144,60 +27144,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
 aa
 "}
 (48,1,1) = {"
@@ -23354,6 +27323,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -23364,6 +27334,36 @@ aa
 aa
 aa
 aa
+Bd
+ed
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+VP
+oJ
+kr
+pg
+pg
+bJ
+jm
+kr
+iG
+sT
+Dl
+FQ
+sT
+iF
+jN
 aa
 aa
 aa
@@ -23401,60 +27401,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
 aa
 "}
 (49,1,1) = {"
@@ -23611,6 +27580,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -23621,6 +27591,36 @@ aa
 aa
 aa
 aa
+Bd
+BM
+OS
+OS
+OS
+OS
+OS
+OS
+XE
+OS
+OS
+OS
+OS
+OS
+OS
+VP
+oJ
+La
+TG
+TG
+Qx
+jm
+kr
+iF
+sT
+sT
+sT
+sT
+iF
+jN
 aa
 aa
 aa
@@ -23658,60 +27658,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
 aa
 "}
 (50,1,1) = {"
@@ -23868,6 +27837,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -23878,6 +27848,36 @@ aa
 aa
 aa
 aa
+Bd
+BM
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+jQ
+oJ
+Uy
+Qx
+Qx
+TG
+jm
+hp
+iF
+sT
+sT
+sT
+sT
+iF
+jN
 aa
 aa
 aa
@@ -23915,60 +27915,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
 aa
 "}
 (51,1,1) = {"
@@ -24125,6 +28094,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -24135,6 +28105,36 @@ aa
 aa
 aa
 aa
+Bd
+BM
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+VP
+oJ
+kr
+TG
+TG
+Qx
+jm
+kr
+iF
+sT
+sT
+sT
+uT
+iF
+jN
 aa
 aa
 aa
@@ -24172,60 +28172,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
 aa
 "}
 (52,1,1) = {"
@@ -24382,6 +28351,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -24392,6 +28362,36 @@ aa
 aa
 aa
 aa
+Bd
+BM
+OS
+OS
+OS
+Gv
+OS
+OS
+OS
+OS
+OS
+OS
+Gv
+OS
+OS
+Vj
+oJ
+UJ
+zl
+SV
+zl
+Bi
+kr
+iF
+sT
+sT
+sT
+sT
+iF
+jN
 aa
 aa
 aa
@@ -24429,60 +28429,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
 aa
 "}
 (53,1,1) = {"
@@ -24639,6 +28608,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -24649,6 +28619,36 @@ aa
 aa
 aa
 aa
+Bd
+BM
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+PC
+oJ
+Jp
+TD
+TD
+bJ
+jm
+kr
+iF
+sT
+sT
+sT
+sT
+iF
+jN
 aa
 aa
 aa
@@ -24686,60 +28686,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+pW
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
 aa
 "}
 (54,1,1) = {"
@@ -24896,6 +28865,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -24906,6 +28876,36 @@ aa
 aa
 aa
 aa
+Bd
+BM
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+VP
+oJ
+Uq
+TG
+TG
+Qx
+jm
+kr
+iF
+sT
+sT
+sT
+sT
+iF
+jN
 aa
 aa
 aa
@@ -24943,60 +28943,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
 aa
 "}
 (55,1,1) = {"
@@ -25153,6 +29122,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -25163,6 +29133,36 @@ aa
 aa
 aa
 aa
+Bd
+BM
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+VP
+oJ
+ah
+Qx
+TG
+TG
+jm
+hp
+iF
+sT
+sT
+sT
+sT
+iF
+jN
 aa
 aa
 aa
@@ -25200,60 +29200,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
 aa
 "}
 (56,1,1) = {"
@@ -25410,6 +29379,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -25420,6 +29390,36 @@ aa
 aa
 aa
 aa
+Bd
+fm
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+VP
+oJ
+kr
+TG
+Qx
+Qx
+jm
+kr
+iG
+sT
+sT
+sT
+uT
+iF
+jN
 aa
 aa
 aa
@@ -25457,60 +29457,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
 aa
 "}
 (57,1,1) = {"
@@ -25667,6 +29636,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -25677,6 +29647,36 @@ aa
 aa
 aa
 aa
+BP
+iF
+ao
+Nk
+Nk
+Bb
+Nk
+Nk
+Nk
+Nk
+Nk
+Bb
+Nk
+Nk
+Nk
+vw
+oJ
+sN
+aR
+aR
+aR
+ab
+kr
+iG
+sT
+sT
+sT
+sT
+iF
+jN
 aa
 aa
 aa
@@ -25714,60 +29714,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
 aa
 "}
 (58,1,1) = {"
@@ -25924,11 +29893,47 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
 aa
 aa
+BP
+GD
+BP
+BP
+BP
+us
+iF
+BC
+jt
+hk
+hk
+hk
+nO
+jt
+jt
+yD
+yD
+yD
+Qq
+jt
+jt
+jt
+jt
+jt
+QJ
+jt
+jt
+JU
+iF
+sT
+sT
+sT
+sT
+iF
+jN
 aa
 aa
 aa
@@ -25966,65 +29971,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
 aa
 "}
 (59,1,1) = {"
@@ -26181,6 +30150,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -26191,6 +30161,36 @@ aa
 aa
 aa
 aa
+BP
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+iF
+jN
 aa
 aa
 aa
@@ -26228,60 +30228,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
 aa
 "}
 (60,1,1) = {"
@@ -26438,6 +30407,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -26448,6 +30418,10 @@ aa
 aa
 aa
 aa
+BP
+BP
+Bd
+iF
 aa
 aa
 aa
@@ -26473,6 +30447,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -26510,35 +30485,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
 aa
 "}
 (61,1,1) = {"
@@ -26695,6 +30664,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -26708,6 +30678,7 @@ aa
 aa
 aa
 aa
+iF
 aa
 aa
 aa
@@ -26733,6 +30704,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -26770,32 +30742,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
 aa
 "}
 (62,1,1) = {"
@@ -26952,6 +30921,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -26965,6 +30935,7 @@ aa
 aa
 aa
 aa
+It
 aa
 aa
 aa
@@ -26990,6 +30961,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -27027,32 +30999,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
 aa
 "}
 (63,1,1) = {"
@@ -27209,6 +31178,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -27248,6 +31218,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -27285,31 +31256,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
 aa
 "}
 (64,1,1) = {"
@@ -27466,6 +31435,7 @@ aa
 aa
 aa
 aa
+jN
 aa
 aa
 aa
@@ -27483,6 +31453,29 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+jN
 aa
 aa
 aa
@@ -27543,30 +31536,6 @@ Di
 Di
 Di
 Di
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 "}
 (65,1,1) = {"
@@ -27723,6 +31692,47 @@ aa
 aa
 aa
 aa
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
+jN
 aa
 aa
 aa
@@ -27759,47 +31769,6 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-Di
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Di
 aa
 aa
 aa
@@ -28034,29 +32003,29 @@ aa
 aa
 aa
 aa
-Di
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -28291,29 +32260,29 @@ aa
 aa
 aa
 aa
-Di
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -28548,29 +32517,29 @@ aa
 aa
 aa
 aa
-Di
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -28805,29 +32774,29 @@ aa
 aa
 aa
 aa
-Di
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -29062,29 +33031,29 @@ aa
 aa
 aa
 aa
-Di
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -29319,29 +33288,29 @@ aa
 aa
 aa
 aa
-Di
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -29576,29 +33545,29 @@ aa
 aa
 aa
 aa
-Di
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -29833,29 +33802,29 @@ aa
 aa
 aa
 aa
-Di
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -30090,29 +34059,29 @@ aa
 aa
 aa
 aa
-Di
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -30347,29 +34316,29 @@ aa
 aa
 aa
 aa
-Di
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-pW
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -30604,29 +34573,29 @@ aa
 aa
 aa
 aa
-Di
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -30861,29 +34830,29 @@ aa
 aa
 aa
 aa
-Di
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -31118,29 +35087,29 @@ aa
 aa
 aa
 aa
-Di
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -31375,29 +35344,29 @@ aa
 aa
 aa
 aa
-Di
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -31632,29 +35601,29 @@ aa
 aa
 aa
 aa
-Di
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -31889,29 +35858,29 @@ aa
 aa
 aa
 aa
-Di
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -32146,29 +36115,29 @@ aa
 aa
 aa
 aa
-Di
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -32403,29 +36372,29 @@ aa
 aa
 aa
 aa
-Di
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -32660,29 +36629,29 @@ aa
 aa
 aa
 aa
-Di
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -32917,29 +36886,29 @@ aa
 aa
 aa
 aa
-Di
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Qe
-Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -33174,29 +37143,29 @@ aa
 aa
 aa
 aa
-Di
-Di
-Di
-Di
-Di
-Di
-Di
-Di
-Di
-Di
-Di
-Di
-Di
-Di
-Di
-Di
-Di
-Di
-Di
-Di
-Di
-Di
-Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -39123,7 +43092,7 @@ Li
 Lb
 bN
 uQ
-bN
+tJ
 Lt
 aa
 aa
@@ -48601,29 +52570,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
 aa
 aa
 aa
@@ -48858,38 +52827,38 @@ aa
 aa
 aa
 aa
+uf
+Lg
+eQ
+GH
+Wn
+Zb
+Wq
+Wq
+Do
+Wq
+Wq
+Wq
+Wq
+Wq
+Wq
+Wq
+Wq
+Do
+Wq
+Wq
+Wq
+pv
+uf
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
 aa
 aa
 aa
@@ -49115,39 +53084,39 @@ uf
 uf
 uf
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+uf
+ga
+kD
+wj
+Wn
+Uf
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+ma
+Wq
+uf
+uf
+uf
+xn
+Wq
+Do
+Wq
+Wq
+Wq
+uf
+uf
 aa
 aa
 aa
@@ -49372,46 +53341,46 @@ eH
 vc
 uf
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+uf
+zA
+wj
+zA
+Wn
+Ct
+Uk
+ad
+Uk
+XN
+Uk
+Uk
+QZ
+Uk
+pa
+Uk
+KG
+Ew
+Mc
+Uk
+kL
+vh
+uf
+xn
+Wq
+Uk
+Uk
+Uk
+Uk
+Uk
+Wq
+Wq
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
 aa
 "}
 (150,1,1) = {"
@@ -49629,46 +53598,46 @@ Wn
 Wn
 uf
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+uf
+uf
+uf
+uf
+uf
+nH
+Uk
+HT
+Uk
+kb
+Uk
+Uk
+QD
+Uk
+Pa
+Uk
+aY
+Es
+mh
+Uk
+VE
+Wq
+uf
+Ca
+Uk
+RS
+Kc
+Uk
+yg
+cQ
+Uk
+vh
+uf
+Gl
+Nu
+SW
+XZ
+zm
+Zn
+uf
 aa
 "}
 (151,1,1) = {"
@@ -49888,44 +53857,44 @@ uf
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+uf
+wj
+uf
+Dx
+Uk
+kQ
+Uk
+JL
+Uk
+Uk
+Tq
+Uk
+YD
+Uk
+OJ
+Uk
+Uk
+Uk
+BL
+Wq
+Wq
+ma
+Uk
+XX
+Mx
+Uk
+ZR
+ZU
+Uk
+Wq
+uf
+Gl
+VH
+Yf
+Gl
+Ok
+sl
+uf
 aa
 "}
 (152,1,1) = {"
@@ -50076,7 +54045,7 @@ aa
 aa
 aa
 aa
-yV
+aa
 aa
 aa
 aa
@@ -50145,44 +54114,44 @@ uf
 FU
 uf
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+uf
+GH
+Wn
+Kb
+Uk
+dH
+Uk
+pC
+Uk
+Uk
+Nv
+Uk
+ZY
+Uk
+WQ
+Uk
+Ba
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Wq
+uf
+Gl
+ii
+IU
+Gl
+JB
+se
+uf
 aa
 "}
 (153,1,1) = {"
@@ -50329,19 +54298,19 @@ aa
 aa
 aa
 aa
-iX
-jk
-jr
-iX
-jr
-jI
-iX
 aa
 aa
 aa
 aa
-iX
-iX
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+iF
+iF
 iF
 iF
 iF
@@ -50402,44 +54371,44 @@ Sz
 Sz
 uf
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+uf
+la
+Wn
+Ig
+Uk
+Uk
+TH
+Uk
+Uk
+Uk
+Uk
+TH
+Uk
+Uk
+Kl
+Uk
+XY
+Uk
+Uk
+Cr
+zY
+JD
+Qw
+Uk
+CN
+zB
+Mg
+Uk
+Uk
+Wq
+uf
+Gl
+rj
+gT
+Gl
+DZ
+wI
+uf
 aa
 "}
 (154,1,1) = {"
@@ -50586,18 +54555,18 @@ aa
 aa
 aa
 aa
-iX
-jl
-js
-iX
-js
-jJ
-iX
 aa
 aa
 aa
 aa
-iX
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+iF
 OM
 mG
 nl
@@ -50659,44 +54628,44 @@ Sz
 Sz
 uf
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+uf
+zA
+Wn
+Mq
+Uk
+VW
+Uk
+hq
+Uk
+Uk
+Ju
+Uk
+JK
+Uk
+Nl
+Uk
+Iy
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Wq
+uf
+Gl
+Ch
+IG
+Gl
+TN
+hr
+uf
 aa
 "}
 (155,1,1) = {"
@@ -50840,20 +54809,20 @@ aa
 aa
 aa
 aa
-iF
-iN
-iX
-iX
-jm
-jr
-iX
-jr
-jK
-iX
-iX
-iX
-iX
-iN
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 iF
 Pg
 mH
@@ -50916,44 +54885,44 @@ Mv
 Mv
 uf
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+uf
+Sr
+uf
+Dx
+Uk
+JF
+Uk
+DS
+Uk
+Uk
+KP
+Uk
+Wr
+Uk
+ek
+Uk
+Uk
+Uk
+Qh
+ma
+Uf
+Uf
+Uk
+Ak
+Sv
+Uk
+mX
+hh
+Uk
+Wq
+uf
+Bc
+Gl
+Gl
+Gl
+jl
+WV
+uf
 aa
 "}
 (156,1,1) = {"
@@ -51097,21 +55066,21 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 iF
-iO
-iO
-jc
-jn
-iP
-jy
-jD
-jL
-jc
-jc
-jc
-iO
-iO
-iX
 md
 iR
 nn
@@ -51174,43 +55143,43 @@ Sz
 uf
 uf
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+uf
+uf
+Oy
+Uk
+Kj
+Uk
+yu
+Uk
+Uk
+Qj
+Uk
+eb
+Uk
+tO
+eJ
+aQ
+Uk
+NF
+Wq
+uf
+Ca
+Uk
+tf
+Hu
+Uk
+Kk
+CS
+Uk
+vh
+uf
+Gl
+pk
+un
+Gl
+vf
+sy
+uf
 aa
 "}
 (157,1,1) = {"
@@ -51354,21 +55323,21 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 iF
-iP
-iP
-jd
-jo
-jt
-jt
-jt
-jM
-jP
-kj
-kj
-jD
-jD
-iX
 me
 mI
 lo
@@ -51430,44 +55399,44 @@ Sz
 Sz
 Wn
 zA
+wj
+GH
+Os
+Me
+Uk
+UF
+Uk
+YI
+Uk
+Uk
+NV
+Uk
+Bt
+Uk
+IB
+Fp
+kt
+Uk
+XB
+vh
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Uf
+Uf
+Uk
+Uk
+Uk
+Uk
+Uk
+ma
+xn
+uf
+Gl
+oq
+nI
+Gl
+sR
+Im
+uf
 aa
 "}
 (158,1,1) = {"
@@ -51611,20 +55580,20 @@ aa
 aa
 aa
 aa
-iF
-iQ
-wa
-xY
-xY
-xY
-xY
-xY
-xY
-xY
-xY
-xY
-ul
-ln
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 iN
 zn
 iR
@@ -51686,45 +55655,45 @@ uf
 Sz
 Sz
 Wn
-ga
+eU
+kD
+wj
+Os
+Uf
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+ma
+Wq
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+uf
+uf
+Uf
+Uf
+MZ
+Uf
+Uf
+xn
+uf
+uf
+Bf
+uf
+uf
+Gl
+fv
+Jk
+uf
 aa
 "}
 (159,1,1) = {"
@@ -51868,21 +55837,21 @@ aa
 aa
 aa
 aa
-iG
-iR
-Ie
-iO
-iO
-oJ
-iO
-oJ
-iO
-oJ
-iO
-iO
-Nk
-lo
-lJ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+bL
 hz
 iR
 lo
@@ -51944,44 +55913,44 @@ Sz
 Sz
 Wn
 zA
+hR
+zA
+Os
+Dx
+Uf
+Uf
+MZ
+Uf
+Uf
+Uf
+Uf
+Uf
+Uf
+Uf
+Uf
+MZ
+Uf
+Uf
+Uf
+Zb
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Wi
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+VC
+zj
+Yh
+uf
+Gl
+BE
+yV
+uf
 aa
 "}
 (160,1,1) = {"
@@ -52125,20 +56094,20 @@ aa
 aa
 aa
 aa
-iG
-iR
-Ie
-jp
-jp
-oJ
-jp
-oJ
-jp
-oJ
-jp
-jp
-Nk
-lo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 iF
 HV
 mJ
@@ -52202,43 +56171,43 @@ Sz
 uf
 uf
 uf
+uf
+uf
+uf
+uf
+Bf
+oG
+Wn
+oG
+Bf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+BP
+qN
+PL
+PL
+fd
+rq
+bl
+zj
+ma
+GK
+uf
+Gl
+Sc
+dr
+uf
 aa
 "}
 (161,1,1) = {"
@@ -52382,20 +56351,20 @@ aa
 aa
 aa
 aa
-iF
-iR
-Ie
-jp
-jp
-oJ
-jp
-oJ
-jp
-oJ
-jp
-jp
-Nk
-EK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 iF
 iF
 iF
@@ -52458,44 +56427,44 @@ uf
 Fj
 uf
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Wi
+Wi
+uf
+VC
+zj
+zj
+KJ
+go
+go
+go
+Zh
+Tk
+NB
+cc
+jo
+dT
+go
+de
+go
+go
+Db
+uf
+uf
+BP
+qN
+PL
+PL
+fd
+tc
+dZ
+ma
+el
+Mh
+uf
+Gl
+lm
+ze
+uf
 aa
 "}
 (162,1,1) = {"
@@ -52639,20 +56608,20 @@ aa
 aa
 aa
 aa
-iG
-iR
-Ie
-jp
-jp
-oJ
-jp
-oJ
-jp
-oJ
-jp
-jp
-Nk
-lp
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 iF
 mi
 kj
@@ -52715,44 +56684,44 @@ Fu
 Sz
 ih
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Wi
+uf
+uf
+zj
+ma
+ma
+rG
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+Tn
+CQ
+uf
+uf
+uf
+bo
+jq
+fd
+xI
+Og
+Dr
+nc
+wf
+uf
+Gl
+xP
+vl
+uf
 aa
 "}
 (163,1,1) = {"
@@ -52896,21 +56865,21 @@ aa
 aa
 aa
 aa
-iG
-iR
-Ws
-Qx
-Qx
-Qx
-Qx
-Qx
-Qx
-Qx
-Qx
-Qx
-kr
-lo
-lK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+bL
 iR
 oJ
 oJ
@@ -52974,42 +56943,42 @@ cs
 uf
 uf
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+yT
+Wh
+pp
+rG
+RD
+RD
+Qa
+Ie
+Ie
+Ie
+mx
+Ie
+Ie
+Ie
+Ie
+Ie
+aV
+RD
+RD
+Tn
+go
+Db
+uf
+ug
+jD
+uf
+uf
+uf
+fo
+uf
+uf
+uf
+uf
+uf
+uf
+uf
 aa
 "}
 (164,1,1) = {"
@@ -53153,20 +57122,20 @@ aa
 aa
 aa
 aa
-iF
-iS
-iZ
-Gl
-jq
-Fm
-xI
-vY
-jN
-jQ
-jN
-Gl
-Gl
-lq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 iF
 mj
 jf
@@ -53185,7 +57154,7 @@ tK
 Ab
 mR
 Ab
-np
+Ab
 Ab
 Ab
 Ab
@@ -53229,42 +57198,42 @@ Xw
 Sz
 cD
 Wn
-wj
+eQ
+Os
+kW
+mv
+RD
+RD
+RD
+Qa
+mr
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+uf
+jZ
+oG
+Wn
+oG
+jZ
+uf
+uf
+Gl
+aV
+RD
+RD
+RD
+JM
+uf
+tU
+qB
+ju
+Wn
+xn
+Wq
+Wq
+Wq
+ID
+bS
+uf
 aa
 aa
 aa
@@ -53410,20 +57379,20 @@ aa
 aa
 aa
 aa
-iF
-iF
-iN
-iF
-iF
-iF
-iF
-iF
-iF
-iF
-iN
-iF
-iF
-iF
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 iF
 iF
 iF
@@ -53486,42 +57455,42 @@ Sz
 Sz
 Rw
 Wn
-IR
+zA
+Os
+Db
+gc
+RD
+Qa
+Ie
+Ja
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+uf
+Uk
+Uk
+AS
+hn
+AS
+Uk
+Uk
+uf
+uf
+Ay
+Ie
+aV
+RD
+dO
+uf
+uo
+gB
+VN
+uf
+Uf
+GS
+xr
+ma
+EK
+lC
+uf
 aa
 aa
 aa
@@ -53667,7 +57636,7 @@ aa
 aa
 aa
 aa
-Vx
+aa
 aa
 aa
 aa
@@ -53743,42 +57712,42 @@ Xw
 Sz
 QU
 uf
-Wn
+Os
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+uf
+du
+RD
+JM
+uf
+uf
+uf
+eT
+pm
+Kz
+Kz
+Kz
+Kz
+Kz
+ZI
+FT
+uf
+uf
+uf
+nw
+RD
+JM
+uf
+ay
+Wq
+cU
+dX
+ma
+PA
+MG
+ma
+hV
+jP
+uf
 aa
 aa
 aa
@@ -53924,7 +57893,7 @@ aa
 aa
 aa
 aa
-Vx
+aa
 aa
 aa
 aa
@@ -53999,43 +57968,43 @@ Pr
 Xw
 Sz
 Qo
-Wn
-zA
+Os
+ux
+wj
+wV
+lY
+RD
+JM
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+lf
+uf
+Uk
+Nj
+SM
+Cw
+SM
+Cw
+SM
+Kz
+Uk
+uf
+nf
+uf
+xQ
+RD
+ua
+uf
+NQ
+ma
+zL
+ma
+ma
+jT
+VX
+ma
+ma
+uD
+uf
 aa
 aa
 aa
@@ -54181,7 +58150,7 @@ aa
 aa
 aa
 aa
-Vx
+aa
 aa
 aa
 aa
@@ -54221,7 +58190,7 @@ io
 vt
 xT
 iu
-BE
+SI
 mk
 CJ
 Ab
@@ -54256,43 +58225,43 @@ Xn
 pY
 Sz
 dJ
+Os
+Ww
+sW
+Uu
+OU
+RD
+JM
 Wn
-wj
+QK
+Wn
+eW
+Nj
+Cw
+SM
+Cw
+SM
+Cw
+Kz
+pK
+Wn
+QK
+Wn
+pz
+RD
+JM
+Bf
+Uf
+ma
+ma
+ma
+ma
+nt
+Xe
+ma
+ma
+Rf
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -54438,7 +58407,7 @@ aa
 aa
 aa
 aa
-Vx
+aa
 aa
 aa
 aa
@@ -54514,42 +58483,42 @@ qk
 Sz
 Cb
 uf
+mZ
+yF
+lk
+OU
+RD
+Nc
 Wn
+sx
+Wn
+lQ
+Nj
+SM
+Ls
+OG
+Cw
+SM
+Kz
+bu
+Wn
+wu
+Wn
+Nb
+RD
+Eh
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Dx
+ma
+ma
+ma
+ma
+ma
+ma
+Uf
+Uf
+xn
+uf
 aa
 aa
 aa
@@ -54695,7 +58664,7 @@ aa
 aa
 aa
 aa
-Vx
+aa
 aa
 aa
 aa
@@ -54735,7 +58704,7 @@ io
 vt
 xo
 mk
-BE
+SI
 iu
 CK
 Ab
@@ -54770,43 +58739,43 @@ Pl
 kd
 Sz
 qd
+Os
+Cs
+ux
+zQ
+OU
+RD
+JM
 Wn
-wj
+uq
+Wn
+eW
+Nj
+Cw
+SM
+Cw
+SM
+Cw
+Kz
+pK
+Wn
+uq
+Wn
+TP
+RD
+JM
+Bf
+Uf
+ma
+ma
+ma
+iQ
+dZ
+tT
+HU
+mm
+Ys
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -54952,7 +58921,7 @@ aa
 aa
 aa
 aa
-Vx
+aa
 aa
 aa
 aa
@@ -55027,43 +58996,43 @@ Pr
 Xw
 Sz
 Qo
-Wn
+Os
 zA
+Sr
+Jo
+lY
+RD
+JM
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Ce
+uf
+Uk
+Nj
+SM
+Cw
+SM
+Cw
+SM
+Kz
+Uk
+uf
+Ce
+uf
+LY
+RD
+ua
+uf
+lX
+Uc
+Hq
+cF
+mu
+xY
+tZ
+nR
+zL
+hE
+uf
 aa
 aa
 aa
@@ -55209,7 +59178,7 @@ aa
 aa
 aa
 aa
-Vx
+aa
 aa
 aa
 aa
@@ -55285,42 +59254,42 @@ Xw
 Sz
 UV
 uf
-Wn
+Os
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+uf
+du
+RD
+JM
+uf
+uf
+uf
+eT
+Hy
+Nj
+Nj
+Nj
+Nj
+Nj
+Ti
+FT
+uf
+uf
+uf
+MT
+RD
+JM
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
 aa
 aa
 aa
@@ -55542,31 +59511,31 @@ Sz
 Sz
 Sg
 Wn
-ga
+wj
+Os
+VC
+OU
+RD
+Tn
+go
+sX
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+uf
+Uk
+Uk
+Jj
+bF
+Jj
+Uk
+Uk
+uf
+uf
+js
+go
+VV
+RD
+dO
+uf
 aa
 aa
 aa
@@ -55742,10 +59711,10 @@ Jb
 uj
 il
 nM
-nM
-nM
-nM
-nM
+qD
+qD
+qD
+qD
 io
 bp
 eP
@@ -55755,7 +59724,7 @@ tN
 Ab
 mR
 Ab
-np
+Ab
 Ab
 Ab
 Ab
@@ -55799,31 +59768,31 @@ Xw
 Sz
 JJ
 Wn
-zA
+mz
+Os
+iA
+LT
+RD
+RD
+RD
+Tn
+Ay
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+uf
+jZ
+oG
+Wn
+oG
+jZ
+uf
+uf
+zj
+VV
+RD
+RD
+RD
+JM
+uf
 aa
 aa
 aa
@@ -56010,13 +59979,13 @@ Gm
 io
 eu
 tN
-mR
-hB
+vk
 tN
+Ab
+Ab
+Ab
 xo
-xo
-xF
-mR
+er
 zG
 RX
 AT
@@ -56058,29 +60027,29 @@ sk
 uf
 uf
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+YB
+TZ
+kg
+aV
+RD
+RD
+Tn
+go
+go
+go
+rp
+go
+go
+go
+go
+go
+VV
+RD
+RD
+Qa
+Ie
+po
+uf
 aa
 aa
 aa
@@ -56268,14 +60237,14 @@ io
 io
 UO
 io
+FA
+Ab
+Ab
+Ab
+xo
 io
-gY
-mk
-gY
-io
-io
-iu
-iu
+MN
+hy
 io
 Zz
 io
@@ -56313,31 +60282,31 @@ Qo
 Sz
 ih
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Wi
+uf
+uf
+zj
+ma
+ma
+aV
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+RD
+Qa
+AM
+uf
+uf
+uf
 aa
 aa
 aa
@@ -56518,21 +60487,21 @@ iU
 jx
 jG
 iu
-Ym
-io
-io
-rK
+yG
 iu
-MF
+JQ
+qz
+iu
+Qn
 io
 vP
 Ku
-vP
-vP
-vP
+Ku
+Ku
+DT
 io
-rK
-mQ
+iu
+iu
 io
 io
 io
@@ -56570,29 +60539,29 @@ uf
 Fj
 uf
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Wi
+Wi
+uf
+Db
+Dr
+Dr
+UB
+Ie
+Ie
+Ie
+xa
+zP
+UZ
+aq
+if
+od
+Ie
+Yz
+Ie
+Ie
+po
+uf
+uf
 aa
 aa
 aa
@@ -56783,15 +60752,15 @@ io
 yj
 io
 io
-Im
+gY
 mk
-Im
+gY
 io
 io
-iu
-iu
-io
-io
+QG
+UE
+ui
+hB
 io
 io
 io
@@ -56828,27 +60797,27 @@ Sz
 uf
 uf
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+uf
+uf
+uf
+uf
+Bf
+oG
+Wn
+oG
+Bf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
 aa
 aa
 aa
@@ -57032,7 +61001,7 @@ Mz
 jw
 jG
 iu
-Ym
+jr
 iu
 Iw
 sK
@@ -57047,7 +61016,7 @@ Fg
 io
 zH
 Aq
-AU
+Aq
 BF
 iu
 zC
@@ -57084,28 +61053,28 @@ Sz
 Sz
 Wn
 zA
+eQ
+GH
+Os
+Zb
+Wq
+Wq
+Do
+Wq
+Wq
+Wq
+Wq
+Do
+Wq
+Wq
+Wq
+Do
+Wq
+pv
+Os
+zA
+wj
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -57289,21 +61258,21 @@ il
 jE
 jG
 iu
-lN
+Oj
 iu
 SQ
 sK
 Ts
-em
+JP
 io
 pr
-Ab
-Ab
-Ab
+Nw
+Nw
+Nw
 tg
 io
 zI
-Ab
+cO
 xN
 BG
 io
@@ -57341,28 +61310,28 @@ Sz
 Sz
 Wn
 ga
+kD
+wj
+Os
+rl
+Uk
+jM
+Uk
+pt
+Uk
+Uk
+Uk
+mP
+Uk
+hb
+Uk
+CG
+Uk
+LZ
+Os
+ga
+GF
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -57546,7 +61515,7 @@ Mz
 jw
 jG
 iu
-Ym
+jr
 iu
 gl
 sK
@@ -57554,14 +61523,14 @@ OH
 yo
 iu
 vR
-Ab
-Ab
-Ab
-yz
+Nw
+hm
+Nw
+th
 iu
 zI
 xN
-Ab
+cO
 BH
 iu
 Ym
@@ -57598,28 +61567,28 @@ Sz
 Sz
 Wn
 zA
+wj
+zA
+Os
+xH
+Uk
+kc
+Uk
+QM
+Uk
+Kp
+Uk
+Yv
+Uk
+Wo
+Uk
+DE
+Uk
+BO
+Os
+zA
+wj
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -57811,13 +61780,13 @@ uc
 uw
 vd
 vS
-wH
-Ab
-Ab
-np
+Nw
+dk
+Nw
+nu
 zk
-zJ
-Ab
+wK
+cO
 xN
 BI
 io
@@ -57858,25 +61827,25 @@ uf
 uf
 uf
 uf
+Dx
+Uk
+Uk
+Uk
+Uk
+Uk
+tY
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+pv
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+uf
+uf
+uf
 aa
 aa
 aa
@@ -58060,22 +62029,22 @@ iT
 jH
 jG
 iu
-qw
+jp
 iu
 ZS
 sK
 GX
 wl
 io
-vR
-Ab
-Ab
-Ab
+yf
+Nw
+pu
+Nw
 yz
 iu
-zJ
+wK
 xN
-Ab
+cO
 BJ
 iu
 lN
@@ -58114,26 +62083,26 @@ uf
 Kg
 Xw
 wW
-cU
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+mb
+Uk
+Fm
+Uk
+Ly
+Uk
+Uk
+Uk
+rU
+Uk
+YZ
+Uk
+ve
+Uk
+tS
+Os
+wj
+zA
+uf
 aa
 aa
 aa
@@ -58317,7 +62286,7 @@ iU
 iU
 lt
 iu
-zC
+xu
 iu
 Cx
 sK
@@ -58325,13 +62294,13 @@ uc
 uw
 vd
 vS
-wH
-Ab
-Ab
-np
+Nw
+DV
+Nw
+nu
 zk
-zJ
-Ab
+wK
+cO
 xN
 Ry
 io
@@ -58371,26 +62340,26 @@ uf
 RA
 Xw
 Gy
-cU
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+iP
+Uk
+BS
+TH
+yB
+Uk
+Fr
+Uk
+CP
+TH
+LO
+Uk
+uA
+Uk
+DM
+Os
+ga
+RN
+uf
 aa
 aa
 aa
@@ -58574,22 +62543,22 @@ et
 ja
 RI
 io
-io
+iu
 io
 en
-uc
-SO
+sK
+AU
 bG
 iu
 hA
-wI
 Nw
-wI
+Nw
+Nw
 Dm
 iu
 zK
 As
-zJ
+As
 YY
 iu
 lN
@@ -58628,26 +62597,26 @@ ER
 Xw
 Fy
 Gy
-cU
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+kN
+Uk
+uJ
+Uk
+Gh
+Uk
+Uk
+Uk
+jk
+Uk
+Gt
+Uk
+gW
+Uk
+AZ
+Os
+zA
+wj
+uf
 aa
 aa
 aa
@@ -58830,29 +62799,29 @@ ps
 Ar
 ps
 yh
-Hv
-cg
-cg
-cg
-UO
-cg
-cg
-cg
-cg
-gY
+io
+Rt
+io
+QL
+qP
+SO
+Lx
+io
+iO
+ai
 GJ
-gY
-cg
-cg
-cg
-cg
-sn
-cg
-cg
-fm
-cg
+ai
+iY
+io
+GG
+Is
+zJ
+ys
+io
+io
+io
 UO
-cg
+io
 NO
 NO
 NO
@@ -58885,26 +62854,26 @@ uf
 RA
 jR
 Gy
-cU
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Dx
+Uk
+Uk
+Uk
+Uk
+Uk
+Qs
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+Uk
+pv
+uf
+uf
+uf
+uf
 aa
 aa
 aa
@@ -59087,28 +63056,28 @@ rM
 rM
 rM
 HW
-Hv
-cg
-PL
-fm
-cO
-fm
-eK
-cg
-vU
+io
+io
+io
+io
+io
+io
+io
+io
+io
 LH
+mk
 vU
-vU
-vU
-cg
-hm
-fm
-cO
-BM
-HH
-ug
-HH
-HH
+io
+io
+io
+io
+io
+io
+io
+Tw
+iu
+uc
 sY
 NO
 NO
@@ -59142,26 +63111,26 @@ uf
 ro
 Xw
 UU
-cU
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+nh
+Uk
+ng
+Uk
+QQ
+Uk
+Az
+Uk
+xq
+Uk
+Wg
+Uk
+jc
+Uk
+nE
+Os
+zA
+wj
+uf
 aa
 aa
 aa
@@ -59345,28 +63314,28 @@ rM
 rM
 RG
 Hv
+Ql
+Ql
 cg
-cg
-cg
-Wc
-cg
-cg
-cg
-cg
+WJ
 EA
-GJ
+yI
 EA
-cg
-cg
-cg
-cg
+ns
+EA
+EA
+EA
+ns
+EA
+yI
+EA
 Wc
 cg
-cg
-cg
-cg
-Wc
-cg
+lN
+oW
+io
+yj
+io
 Yn
 sZ
 Yn
@@ -59400,25 +63369,25 @@ uf
 uf
 uf
 uf
+IX
+Uk
+Jx
+Uk
+zN
+Uk
+jb
+Uk
+iJ
+Uk
+vV
+Uk
+VD
+Uk
+sU
+Os
+zA
+RN
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -59601,36 +63570,36 @@ rM
 rM
 rM
 zc
-Hv
-qy
-qz
+RI
+EP
+Ql
 cg
-sN
-bL
+sP
 Sj
-JU
-xr
-wK
-Rf
-wK
-xr
-JU
-uA
-bL
-AV
+Sj
+Sj
+Sj
+Sj
+Sj
+Sj
+Sj
+Sj
+Sj
+Sj
+tV
 cg
-qz
-cg
-Rs
-HH
+iu
+vN
+io
+fn
 Yn
 Pz
 Su
 qI
-Uw
+iM
 PV
 PV
-NO
+Ob
 NO
 NO
 Uw
@@ -59656,26 +63625,26 @@ uf
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+uf
+Dx
+Uf
+Uf
+MZ
+Uf
+Uf
+Uf
+Uf
+MZ
+Uf
+Uf
+Uf
+MZ
+Uf
+Zb
+Os
+wj
+zA
+uf
 aa
 aa
 aa
@@ -59859,27 +63828,27 @@ ps
 ps
 Wp
 Hv
-qz
-qy
+Ql
+qX
 cg
-sO
-bJ
-IX
-xt
-xt
-xt
-xt
-xt
-xt
-xt
-us
-Lx
-AW
+kP
+Sj
+Sj
+Sj
+xZ
+iS
+VJ
+ku
+dh
+Sj
+Sj
+Sj
+Hf
 cg
-qz
-cg
+qM
+dc
 pf
-HH
+dP
 Yn
 Ty
 Su
@@ -59913,26 +63882,26 @@ uf
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
 aa
 aa
 aa
@@ -60116,25 +64085,25 @@ ja
 ja
 Hv
 Hv
-qA
-qy
-fm
-sP
-tT
-xt
-ve
-xt
-xt
-xt
-xt
-xt
-xt
-xt
-vZ
-AX
-fm
-Cd
+Hv
+IC
 cg
+sP
+Sj
+Sj
+Sj
+jn
+xb
+ic
+Vd
+we
+Sj
+Sj
+Sj
+AX
+cg
+qy
+bI
 Xk
 SG
 Yn
@@ -60372,28 +64341,28 @@ pc
 ps
 ps
 SD
+mM
 Hv
-qy
-qz
+RI
 cg
 fE
-tT
-xt
-vf
-vX
-xt
+Sj
+Oi
+Sj
+hS
+vg
 PG
-xt
-xt
-xt
-xt
-vZ
+UN
+nx
+Sj
+Oi
+Sj
 aP
 cg
 qy
-cg
+DO
 Rs
-HH
+DO
 Yn
 KF
 KF
@@ -60405,12 +64374,12 @@ Yn
 NO
 NO
 Yn
+sn
 EZ
 EZ
 EZ
 EZ
 EZ
-QM
 Yn
 NE
 NE
@@ -60619,8 +64588,8 @@ NW
 rM
 rM
 ct
-ps
-ps
+Td
+dN
 Zx
 Ez
 GT
@@ -60628,46 +64597,46 @@ RI
 ps
 rk
 rk
+rk
 Ar
 Hv
-qy
-qz
+IC
 cg
-sQ
-tT
+hl
+Sj
+Sj
+Sj
+jJ
+Kr
+GW
 xt
-vf
-xZ
-vX
-xt
-xt
-xt
-xt
-xt
-vZ
-AY
+JZ
+Sj
+Sj
+Sj
+mV
 cg
-fm
-cg
-cg
+iu
+io
+io
 sL
 Yn
 AH
 Qp
 AH
 AH
-OP
+te
 PK
 Yn
 PV
 PV
 Yn
 Vn
+jy
 PW
-Vn
-PW
+jy
 SE
-zZ
+jy
 Yn
 NE
 FR
@@ -60885,32 +64854,32 @@ Hv
 xE
 mY
 rM
-OS
-Hv
-cg
-fm
-cg
+rM
+ps
+RI
+EP
+qW
 sQ
-tT
-xt
-ve
+Sj
+Sj
+Sj
+wa
+GA
+vy
+ln
 wL
-wL
-wL
-wL
-wL
-yB
-xt
-vZ
+Sj
+Sj
+Sj
 AY
-cg
-pg
-Uf
-TG
-HH
+qW
+Ts
+em
+Iw
+fn
 Yn
-OP
-AH
+EG
+Zc
 AH
 AH
 OP
@@ -60920,10 +64889,10 @@ UM
 UM
 sZ
 Vn
+zZ
 PW
-Vn
+zZ
 PW
-Vn
 zZ
 Yn
 NE
@@ -61142,29 +65111,29 @@ RI
 MV
 mY
 rM
+rM
 HM
 Hv
-qB
-qW
-rT
+Ql
+cg
 sO
-tT
-xt
-vg
-Vd
-xZ
-xZ
 dh
+Sj
+Sj
+Sj
+xZ
+Go
 dh
-zl
-xt
-vZ
-AW
-BN
-Cf
+Sj
+Sj
+Sj
+xZ
+BZ
+yJ
+Xv
+dA
 HH
-HH
-HH
+Va
 Yn
 OP
 OP
@@ -61177,10 +65146,10 @@ QO
 QO
 sZ
 Vn
+zZ
 PW
-Vn
+zZ
 PW
-Vn
 zZ
 Yn
 NE
@@ -61399,28 +65368,28 @@ RI
 MV
 mY
 rM
-Np
+rM
+Mm
 Hv
-qC
-qX
-rU
-sO
-tT
-xt
-rq
-xt
-Vd
+RI
+cg
+Hc
+vX
+Oi
+Sj
+Sj
+vZ
 Dg
 vX
-xt
-rq
-xt
+Sj
+Sj
+Oi
 vZ
 DU
-BO
-Cg
-HH
-HH
+cg
+Ov
+JN
+Ia
 rt
 Yn
 AH
@@ -61434,11 +65403,11 @@ OA
 Zy
 Yn
 Vn
-SE
-Vn
-Vn
-Vn
+RE
 zZ
+Cc
+zZ
+kp
 Yn
 NE
 NE
@@ -61656,27 +65625,27 @@ RI
 MV
 mY
 rM
+rM
 sJ
 Hv
-qD
-qY
-rV
-sO
-tT
-xt
-ve
+Ql
+cg
+Rg
 wL
+Sj
+Sj
+Sj
+wa
+EA
 wL
-xZ
-xZ
-vX
-yB
-xt
-vZ
-AW
-BP
+Sj
+Sj
+Sj
+wa
+hj
+Cd
 Cf
-HH
+TY
 UA
 zf
 Yn
@@ -61691,10 +65660,10 @@ NO
 NO
 Yn
 Tz
-Tz
-Tz
-Tz
-Tz
+zE
+zE
+zE
+zE
 zE
 Yn
 NE
@@ -61913,25 +65882,25 @@ ct
 ps
 rM
 rM
+rM
 Pk
-Hv
-cg
-fm
-cg
+RI
+EP
+qW
 sQ
-tT
-xt
-vg
+Sj
+Sj
+Sj
+xZ
+iS
+VJ
+ku
 dh
-dh
-dh
-dh
-dh
-zl
-xt
-vZ
+Sj
+Sj
+Sj
 AY
-cg
+qW
 VY
 Xb
 CE
@@ -61944,8 +65913,8 @@ Yn
 Yn
 Yn
 Yn
-XT
-XT
+NO
+NO
 Yn
 Yn
 Yn
@@ -62170,29 +66139,29 @@ RI
 MV
 mY
 rM
+rM
 ML
 Hv
-qz
-qy
+IC
 cg
-sR
-tT
-xt
-xt
-xt
-xt
-xt
+Ei
+Sj
+Sj
+Sj
+jn
+xb
+jd
 Vd
-xZ
-zm
-xt
-vZ
-AZ
-ku
-fm
+we
+Sj
+Sj
+Sj
+vj
 cg
-cg
-cg
+iu
+io
+io
+io
 Yn
 zM
 zM
@@ -62201,14 +66170,14 @@ zM
 zM
 zs
 Yn
-aa
-aa
+NO
+NO
 Yn
 Pv
-Pv
-Pv
-Pv
-Pv
+ZQ
+ZQ
+ZQ
+ZQ
 ZQ
 Yn
 NE
@@ -62427,46 +66396,46 @@ RI
 MV
 mY
 rM
-Np
+rM
+Mm
 Hv
-qy
-qz
+RI
 cg
 fE
-tT
-xt
-xt
-xt
-xt
+Sj
+Oi
+Sj
+nd
+vg
 PG
-xt
-Vd
-zm
-xt
-vZ
+UN
+yN
+Sj
+Oi
+Sj
 aP
 cg
-qz
-cg
+rK
+io
 Nh
 Ro
 Yn
 Se
 MP
+Si
 Se
-Se
-Se
+Fn
 Tc
 Yn
-aa
-aa
+Gz
+wQ
 Yn
-Pm
-Pm
-Pm
-Xh
+eK
+dm
+dm
+dm
 mc
-Wt
+Xh
 Yn
 NE
 NE
@@ -62684,46 +66653,46 @@ RI
 MV
 mY
 rM
+rM
 RP
 Hv
-qA
-qy
-fm
-sS
-tT
-xt
-xt
-xt
-xt
-xt
-xt
-xt
-zl
-xt
-vZ
-Bb
-fm
-Cd
+IC
 cg
+sS
+Sj
+Sj
+Sj
+jJ
+Kr
+GW
+xt
+JZ
+Sj
+Sj
+Sj
+tV
+cg
+mQ
+io
 MI
-NO
+IS
 Yn
-Se
+qC
 Si
 Se
-Si
-Se
+qC
+Fn
 Tc
-Yn
-aa
-aa
-Yn
-Xh
-Xh
+sZ
+UM
+UM
+sZ
+eK
 Pm
-Xh
-Xh
+Pm
 Wt
+Xh
+Xh
 Yn
 NE
 NE
@@ -62941,46 +66910,46 @@ Hv
 xE
 mY
 rM
-NW
-Hv
-qz
-qy
-cg
-sO
-da
-GD
-xt
-xt
-xt
-xt
-xt
-xt
-xt
-bo
-At
+rM
+ps
+RI
+dD
+qW
+IW
+Sj
+Sj
+Sj
+wa
+GA
+vy
+ln
+wL
+Sj
+Sj
+Sj
 AW
-cg
-qy
-cg
+qW
+gF
+io
 OD
-NO
+IS
 Yn
+ul
 Se
+qC
 Si
-Se
-Si
-Se
+Fn
 Tc
-Yn
-aa
-aa
-Yn
-Xh
-Xh
-Pm
+sZ
+QO
+QO
+sZ
+eK
 Xh
 Xh
 Wt
+Xh
+Xh
 Yn
 NE
 FR
@@ -63198,45 +67167,45 @@ RI
 ps
 rk
 rk
+rk
 Aj
 Hv
-qz
-qy
+IC
 cg
-sT
-tU
-Bd
+Wz
+Sj
+Sj
+Sj
+Sj
+Sj
 uG
-uG
-uG
-uG
-uG
-uG
-uG
-dc
-tU
-Bc
+Sj
+Sj
+Sj
+Sj
+Sj
+AV
 cg
-qz
-cg
+rK
+io
 sa
-NO
+IS
 Yn
-Se
-Se
-Se
+Oe
+qC
+Si
 Si
 RL
 Tc
 Yn
-aa
-aa
+aC
+aC
 Yn
-Pm
+eK
 EE
-Pm
-Pm
-Pm
+Wt
+Wt
+Wt
 Wt
 Yn
 NE
@@ -63454,30 +67423,30 @@ dp
 gC
 ps
 Ha
+Ij
 gA
-bC
+LE
 Hv
+RI
 cg
-cg
-cg
-tV
-tV
+sP
+Sj
 Oi
-tV
-tV
-tV
+Sj
+Sj
+Sj
 Oi
-tV
-tV
-tV
+Sj
+Sj
+Sj
 Oi
+Sj
 tV
-tV
 cg
-cg
-cg
+mQ
+io
 Tj
-Su
+cx
 Yn
 Vk
 Vk
@@ -63486,15 +67455,15 @@ Vk
 Vk
 Oq
 Yn
-aa
-aa
+NO
+NO
 Yn
+nU
 Co
 Co
 Co
 Co
 Co
-VP
 Yn
 NE
 NE
@@ -63714,25 +67683,25 @@ Hv
 Hv
 Hv
 Hv
+Hv
+AP
 cg
+wc
+xF
+xF
+xF
+xF
+xF
+xF
+xF
+xF
+xF
+xF
+xF
+Hk
 cg
-cg
-sV
-sV
-sV
-sV
-sV
-sV
-sV
-sV
-sV
-sV
-sV
-sV
-sV
-cg
-cg
-cg
+rK
+io
 XT
 XT
 Yn
@@ -63743,8 +67712,8 @@ Yn
 Yn
 Yn
 Yn
-aa
-aa
+XT
+XT
 Yn
 Yn
 Yn
@@ -63971,25 +67940,25 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-uz
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Hv
+Hv
+cg
+sV
+sV
+sV
+sV
+sV
+sV
+sV
+sV
+sV
+sV
+sV
+sV
+sV
+cg
+io
+io
 aa
 aa
 aa
@@ -64234,7 +68203,7 @@ aa
 aa
 aa
 aa
-aa
+uz
 aa
 aa
 aa

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -2002,9 +2002,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "gZ" = (


### PR DESCRIPTION

## О изменениях в ПРе
изменяем карту цк, теперь на цк есть тестовая арена. Отдел стыковки так же переделан. Карго теперь отдельно от цк
<details>
  <summary>изменения</summary>
<img width="3008" height="3904" alt="StrongDMM-2026-05-21 17 35 49" src="https://github.com/user-attachments/assets/9eb74f04-df05-4854-945a-24641aee6c72" />
<img width="1184" height="1248" alt="StrongDMM-2026-05-21 17 30 59" src="https://github.com/user-attachments/assets/7491c9c8-1fb3-4bde-8984-667adb53408c" />
</details>

## Почему это стоит добавить в игру
## Изменения
:cl: MassMeta: glamyr
map: Переделка цк: добавлен Саратов (местный тест чембер), ремап прибытия цк. Карго отдельно от цк
/:cl:
