### PR TITLE
fixes set_announcement_voices not being called anywhere

### DIFF
--- a/code/controllers/subsystem/tts.dm
+++ b/code/controllers/subsystem/tts.dm
@@ -193,6 +193,11 @@ SUBSYSTEM_DEF(tts)
 		computer_voice = CONFIG_GET(string/tts_computer_voice_override)
 	else
 		computer_voice = pick(available_speakers)
+	// MASSMETA EDIT START (ntts && /tg/tts)
+	if(CONFIG_GET(string/centcom_voice))
+		set_announcement_voices()
+	// MASSMETA EDIT END (ntts && /tg/tts)
+
 	var/datum/http_request/request_pitch = new()
 	var/list/headers_pitch = list()
 	headers_pitch["Authorization"] = CONFIG_GET(string/tts_http_token)


### PR DESCRIPTION
моё лицо когда типа такой нарисовал хелпер на выбор голосов, но забыл вызвать его

<img width="399" height="403" alt="97e2ee7c873d90eacd33ac5da1f1c142" src="https://github.com/user-attachments/assets/41ea47af-0588-4246-9492-adf5a0d7f214" />


:cl: MassMeta
fix: set_announcement_voices() вызывается корректно
/:cl:

