### PR TITLE
Увеличение стоимости на Секрайфлы💸📈

### DIFF
--- a/modular_meta/features/security_extended/code/supply/security_pack.dm
+++ b/modular_meta/features/security_extended/code/supply/security_pack.dm
@@ -2,7 +2,7 @@
 	name = "Security Laser Rifle Crate"
 	desc = "Contains single Security Laser Rifle and powerpack to it. Developed by Research Nanotrasen group. \
 		For security department, ."
-	cost = CARGO_CRATE_VALUE * 10
+	cost = CARGO_CRATE_VALUE * 50
 	contains = list(/obj/item/gun/ballistic/automatic/laser/station = 1, /obj/item/ammo_box/magazine/recharge/station = 2)
 	crate_name = "security laser rifle crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma


### PR DESCRIPTION
Mmm, Tomboy Jams. 🎧
Выше. Их цена в 2 раза дешевле секпушки от оффов, так как секрайфл имеется ее прямой заменой, хоть и более удешевленной. 

:cl: Pikita
balance: Цена секрайфлов была увеличена, в связи с их низкой ценой и большой эффективностью.💸📈
/:cl: