### PR TITLE
debug

### DIFF
--- a/modular_meta/features/jukeboxes_music/code/music.dm
+++ b/modular_meta/features/jukeboxes_music/code/music.dm
@@ -156,7 +156,7 @@
 
 	var/shell_command = "yt-dlp -x --audio-format vorbis --audio-quality 5 -o \"[output_template].%(ext)s\" \"[safe_url]\""
 
-	shell(shell_command)
+	var/list/output = world.shelleo(shell_command)
 
 	var/check_attempts = 0
 	while(!fexists(current_stream_path) && check_attempts < 40)
@@ -164,7 +164,8 @@
 		check_attempts++
 
 	if(!fexists(current_stream_path) || !internet_playing)
-		stack_trace("Jukebox: Failed to download or extract audio from YouTube. Check server yt-dlp/ffmpeg installation.")
+		stack_trace("Jukebox: Failed to download or extract audio from YouTube. Check server yt-dlp/ffmpeg installation.\
+		output: [output]")
 		say("Unexpected error happened during your request")
 		playsound(src, 'sound/machines/compiler/compiler-failure.ogg' , 50)
 		internet_playing = FALSE

--- a/modular_meta/features/jukeboxes_music/code/music.dm
+++ b/modular_meta/features/jukeboxes_music/code/music.dm
@@ -165,7 +165,7 @@
 
 	if(!fexists(current_stream_path) || !internet_playing)
 		stack_trace("Jukebox: Failed to download or extract audio from YouTube. Check server yt-dlp/ffmpeg installation.")
-		log_internet_request("Jukebox \
+		log_game("Jukebox \
 		error code: [output[1]] \
 		stdout: [output[2]] \
 		stderr: [output[3]]")

--- a/modular_meta/features/jukeboxes_music/code/music.dm
+++ b/modular_meta/features/jukeboxes_music/code/music.dm
@@ -164,11 +164,12 @@
 		check_attempts++
 
 	if(!fexists(current_stream_path) || !internet_playing)
-		stack_trace("Jukebox: Failed to download or extract audio from YouTube. Check server yt-dlp/ffmpeg installation.")
-		log_game("Jukebox \
-		error code: [output[1]] \
-		stdout: [output[2]] \
-		stderr: [output[3]]")
+		stack_trace("Jukebox: Failed to download or extract audio from YouTube. Check server-logs for details.")
+		log_runtime("Jukebox: Failed to download or extract audio from YouTube.", list(
+			"Code: [output[1]]",
+			"Output: [output[2]]",
+			"Error:" [output[3]])
+		)
 
 		say("Unexpected error happened during your request")
 		playsound(src, 'sound/machines/compiler/compiler-failure.ogg' , 50)

--- a/modular_meta/features/jukeboxes_music/code/music.dm
+++ b/modular_meta/features/jukeboxes_music/code/music.dm
@@ -164,8 +164,12 @@
 		check_attempts++
 
 	if(!fexists(current_stream_path) || !internet_playing)
-		stack_trace("Jukebox: Failed to download or extract audio from YouTube. Check server yt-dlp/ffmpeg installation.\
-		output: [output]")
+		stack_trace("Jukebox: Failed to download or extract audio from YouTube. Check server yt-dlp/ffmpeg installation.")
+		log_internet_request("Jukebox \
+		error code: [output[1]] \
+		stdout: [output[2]] \
+		stderr: [output[3]]")
+
 		say("Unexpected error happened during your request")
 		playsound(src, 'sound/machines/compiler/compiler-failure.ogg' , 50)
 		internet_playing = FALSE


### PR DESCRIPTION


:cl: Bruh24
code: Jukebox теперь использует shelleo() вместо shell()
code: Jukebox теперь корректно показывает вывод команд yt-dlp и ffmpeg
/:cl:


