### PR TITLE
Tram is now more open

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -1642,6 +1642,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/open/openspace,
 /area/station/asteroid)
 "afB" = (
@@ -1649,6 +1652,9 @@
 /obj/structure/railing/corner,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/railing{
+	dir = 1
 	},
 /turf/open/openspace,
 /area/station/asteroid)
@@ -1668,12 +1674,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/open/openspace,
 /area/station/asteroid)
 "afE" = (
-/obj/structure/lattice,
 /obj/structure/railing{
 	dir = 4
+	},
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/corner{
+	dir = 8
 	},
 /turf/open/openspace,
 /area/station/asteroid)
@@ -1689,16 +1701,22 @@
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "afG" = (
-/obj/structure/lattice,
 /obj/structure/railing{
 	dir = 8
+	},
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/corner{
+	dir = 4
 	},
 /turf/open/openspace,
 /area/station/asteroid)
 "afJ" = (
-/obj/structure/lattice,
 /obj/structure/railing/corner{
 	dir = 4
+	},
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 10
 	},
 /turf/open/openspace,
 /area/station/asteroid)
@@ -1710,16 +1728,27 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
-/obj/structure/lattice,
-/turf/open/openspace,
-/area/station/asteroid)
-"afN" = (
-/obj/structure/lattice,
-/obj/structure/railing/corner{
-	dir = 1
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 6
 	},
 /turf/open/openspace,
 /area/station/asteroid)
+"afN" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Wing"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/station/hallway/primary/tram/center)
 "afR" = (
 /obj/machinery/computer/order_console/mining,
 /obj/effect/turf_decal/tile/brown/fourcorners,
@@ -1744,19 +1773,26 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "agb" = (
-/obj/structure/lattice,
 /obj/structure/railing/corner,
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 9
+	},
 /turf/open/openspace,
 /area/station/asteroid)
 "agd" = (
-/obj/structure/lattice,
 /obj/structure/railing/corner{
 	dir = 8
+	},
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 5
 	},
 /turf/open/openspace,
 /area/station/asteroid)
 "age" = (
 /obj/structure/lattice/catwalk,
+/obj/structure/railing,
 /turf/open/openspace,
 /area/station/asteroid)
 "agf" = (
@@ -1764,6 +1800,7 @@
 /obj/structure/railing/corner{
 	dir = 4
 	},
+/obj/structure/railing,
 /turf/open/openspace,
 /area/station/asteroid)
 "agg" = (
@@ -1778,6 +1815,7 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
+/obj/structure/railing,
 /turf/open/openspace,
 /area/station/asteroid)
 "agi" = (
@@ -2245,15 +2283,15 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
 "aiB" = (
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/tram/right)
@@ -3351,12 +3389,8 @@
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "auq" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Utilities Access Hatch"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/catwalk_floor,
+/turf/closed/wall,
 /area/station/hallway/primary/tram/center)
 "aur" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
@@ -4273,24 +4307,22 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
 "aEh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	frequency = 1449;
-	id_tag = "mostleft_upper_eva_external";
-	autoclose = 0
-	},
-/obj/machinery/door_buttons/access_button{
-	name = "External Access Button";
-	pixel_y = 24;
-	idSelf = "mostleft_upper_eva_airlock_control";
-	idDoor = "mostleft_upper_eva_external"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/catwalk_floor,
+/obj/machinery/door/airlock/public/glass{
+	name = "West Wing"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/left)
 "aEj" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -4338,9 +4370,18 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "aEv" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/right)
+/obj/machinery/door/airlock/public/glass{
+	name = "West Wing"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/station/hallway/primary/tram/left)
 "aEz" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -4388,9 +4429,13 @@
 /turf/open/floor/cult,
 /area/station/service/chapel/office)
 "aEP" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Power Access Hatch"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/left)
+/turf/open/floor/plating,
+/area/station/maintenance/tram/right)
 "aET" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
@@ -4492,7 +4537,6 @@
 	idInterior = "middleright_lower_upper_eva_internal";
 	idExterior = "middleright_lower_upper_eva_external"
 	},
-/obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/tram/mid)
@@ -4557,21 +4601,10 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "aGL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	frequency = 1449;
-	id_tag = "mostleft_lower_eva_internal";
-	autoclose = 0
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
 	},
-/obj/machinery/door_buttons/access_button{
-	name = "External Access Button";
-	pixel_y = -24;
-	idSelf = "mostleft_lower_eva_airlock_control";
-	idDoor = "mostleft_lower_eva_internal"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/catwalk_floor,
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/left)
 "aGY" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -4587,66 +4620,39 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/medical/coldroom)
 "aHe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door_buttons/airlock_controller{
-	name = "External Access Console";
-	pixel_y = -24;
-	idSelf = "mostleft_lower_eva_airlock_control";
-	idInterior = "mostleft_lower_eva_internal";
-	idExterior = "mostleft_lower_eva_external"
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/left)
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
 "aHf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door_buttons/airlock_controller{
-	name = "External Access Console";
-	pixel_y = -24;
-	idSelf = "middleleft_lower_eva_airlock_control";
-	idInterior = "middleleft_lower_eva_internal";
-	idExterior = "middleleft_lower_eva_external"
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
 	},
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/center)
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 1
+	},
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/tram/right)
 "aHl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door_buttons/airlock_controller{
-	name = "External Access Console";
-	pixel_y = -24;
-	idSelf = "middleright_lower_eva_airlock_control";
-	idInterior = "middleright_lower_eva_internal";
-	idExterior = "middleright_lower_eva_external"
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/corner/end{
+	dir = 8
 	},
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/center)
+/turf/open/openspace,
+/area/station/asteroid)
 "aHn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door_buttons/airlock_controller{
-	name = "External Access Console";
-	pixel_y = -24;
-	idSelf = "rightmost_lower_eva_airlock_control";
-	idInterior = "rightmost_lower_eva_internal";
-	idExterior = "rightmost_lower_eva_external"
-	},
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/right)
 "aHo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	frequency = 1449;
-	id_tag = "rightmost_lower_eva_internal";
-	autoclose = 0
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/corner/end{
+	dir = 4
 	},
-/obj/machinery/door_buttons/access_button{
-	name = "External Access Button";
-	pixel_y = -24;
-	idSelf = "rightmost_lower_eva_airlock_control";
-	idDoor = "rightmost_lower_eva_internal"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/right)
+/turf/open/openspace,
+/area/station/asteroid)
 "aHp" = (
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5200,11 +5206,11 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
 "aMt" = (
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/multilayer/multiz,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/tram/right)
 "aMv" = (
@@ -6645,10 +6651,13 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "bly" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/dim/directional/south,
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/right)
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/corner,
+/turf/open/openspace,
+/area/station/asteroid)
 "blN" = (
 /obj/machinery/button/door/directional/west{
 	name = "Privacy Bolts";
@@ -6884,11 +6893,16 @@
 /turf/open/floor/glass/reinforced,
 /area/station/science/research)
 "brf" = (
-/obj/structure/table,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
+/obj/structure/cable/multilayer/multiz,
+/obj/structure/disposalpipe/trunk/multiz/down{
+	dir = 4
 	},
-/obj/item/pai_card,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "brm" = (
@@ -7378,14 +7392,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "bAj" = (
-/obj/machinery/door/airlock/engineering/glass{
+/obj/structure/cable,
+/obj/machinery/door/airlock/hatch{
 	name = "Tram Mechanical Room"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/unres/delayed{
-	dir = 8
-	},
-/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/right)
 "bAK" = (
@@ -7788,7 +7798,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "bIs" = (
-/obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/dim/directional/west,
 /turf/open/floor/iron/smooth,
@@ -8751,21 +8760,17 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "bXG" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	frequency = 1449;
-	id_tag = "rightmost_lower_eva_external";
-	autoclose = 0
+/obj/machinery/door/airlock/public/glass{
+	name = "East Wing"
 	},
-/obj/machinery/door_buttons/access_button{
-	name = "External Access Button";
-	pixel_y = -24;
-	idSelf = "rightmost_lower_eva_airlock_control";
-	idDoor = "rightmost_lower_eva_external"
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/right)
 "bXI" = (
 /obj/machinery/door/firedoor,
@@ -9157,8 +9162,9 @@
 /turf/open/floor/iron/checker,
 /area/station/commons/lounge)
 "ccU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/dim/directional/north,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "ccX" = (
@@ -9682,8 +9688,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light/small/dim/directional/north,
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "clT" = (
 /turf/closed/wall,
@@ -9977,6 +9985,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
 "crR" = (
@@ -10079,7 +10088,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
 "csA" = (
@@ -10720,9 +10731,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -11693,6 +11701,7 @@
 	name = "Arrival Checkpoint Enforcement Override";
 	req_access = list("kitchen")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "cVd" = (
@@ -11836,10 +11845,12 @@
 /area/station/service/bar/backroom)
 "cXc" = (
 /obj/effect/turf_decal/siding/thinplating/corner,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/junction/yjunction,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "cXe" = (
@@ -11882,20 +11893,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/right)
 "cYe" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Tram Mechanical Room"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/unres/delayed{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/port/central)
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/smooth,
+/area/station/hallway/primary/tram/left)
 "cYh" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /turf/open/floor/iron,
@@ -12310,7 +12313,6 @@
 /area/station/commons/fitness)
 "deU" = (
 /obj/structure/closet/emcloset,
-/obj/machinery/light/dim/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/right)
 "deX" = (
@@ -12772,21 +12774,17 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
 "dnp" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	frequency = 1449;
-	id_tag = "middleleft_lower_eva_external";
-	autoclose = 0
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Wing"
 	},
-/obj/machinery/door_buttons/access_button{
-	name = "External Access Button";
-	pixel_y = -24;
-	idSelf = "middleleft_lower_eva_airlock_control";
-	idDoor = "middleleft_lower_eva_external"
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "dnE" = (
 /obj/machinery/telecomms/server/presets/service,
@@ -13024,13 +13022,12 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "drW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light/small/dim/directional/south,
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/left)
 "dsl" = (
 /obj/structure/chair/pew/right,
@@ -13609,8 +13606,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "dCJ" = (
-/obj/machinery/light/small/dim/directional/south,
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "dCU" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -13683,13 +13681,12 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/disposal)
 "dEo" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/right)
@@ -13697,24 +13694,14 @@
 /turf/closed/wall/r_wall,
 /area/station/security/armory)
 "dEH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	frequency = 1449;
-	id_tag = "middleleft_upper_eva_internal";
-	autoclose = 0
-	},
-/obj/machinery/door_buttons/access_button{
-	name = "External Access Button";
-	pixel_y = -24;
-	idSelf = "middleleft_upper_eva_airlock_control";
-	idDoor = "middleleft_upper_eva_internal"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/catwalk_floor,
+/obj/machinery/light/warm/directional/north,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "dEM" = (
 /obj/structure/disposalpipe/junction/flip{
@@ -13965,8 +13952,11 @@
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
 "dJk" = (
-/obj/structure/sign/warning/electric_shock,
-/turf/closed/wall,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/right)
 "dJm" = (
 /obj/structure/chair{
@@ -14142,14 +14132,23 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/solars/port)
 "dMw" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Emergency Exit"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Wing"
+	},
 /obj/structure/cable,
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "dME" = (
 /turf/closed/wall,
@@ -15109,11 +15108,6 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"ecX" = (
-/obj/structure/ladder,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/tram/mid)
 "edg" = (
 /obj/machinery/duct,
 /obj/structure/cable,
@@ -15682,25 +15676,22 @@
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "eqK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	frequency = 1449;
-	id_tag = "middleright_upper_eva_external";
-	autoclose = 0
-	},
-/obj/machinery/door_buttons/access_button{
-	name = "External Access Button";
-	pixel_y = 24;
-	idSelf = "middleright_upper_eva_airlock_control";
-	idDoor = "middleright_upper_eva_external"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/catwalk_floor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Wing"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "eqL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -15951,7 +15942,6 @@
 /turf/open/floor/wood/large,
 /area/station/service/theater)
 "ewh" = (
-/obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/tram/left)
@@ -16427,11 +16417,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"eDD" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/random/decoration/lavalamp,
-/turf/open/floor/iron/dark,
-/area/station/service/bar)
 "eDk" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 8
@@ -16441,6 +16426,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
+"eDD" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/decoration/lavalamp,
+/turf/open/floor/iron/dark,
+/area/station/service/bar)
 "eDG" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -18318,13 +18308,15 @@
 /turf/open/space/openspace,
 /area/station/solars/port)
 "fnL" = (
-/obj/structure/cable/multilayer/multiz,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/hallway/primary/tram/left)
+/obj/effect/turf_decal/trimline/white/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/tram/left)
 "fnO" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
@@ -19793,9 +19785,11 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "fQF" = (
-/obj/machinery/newscaster/directional/east,
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
@@ -19871,14 +19865,16 @@
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "fRW" = (
-/obj/machinery/newscaster/directional/east,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/left)
 "fSc" = (
@@ -20041,13 +20037,20 @@
 /turf/open/floor/plating,
 /area/station/ai/satellite/foyer)
 "fVN" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Emergency Exit"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/catwalk_floor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Wing"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "fVX" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
@@ -20205,10 +20208,14 @@
 /area/station/security/execution/education)
 "fYl" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/effect/turf_decal/trimline/neutral/filled/warning,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 10
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
@@ -20322,7 +20329,10 @@
 /turf/open/openspace,
 /area/station/hallway/primary/tram/right)
 "gaH" = (
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/right)
 "gaO" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
@@ -20946,13 +20956,9 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/tram/mid)
 "gmm" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Utilities Access Hatch"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/catwalk_floor,
+/obj/structure/cable,
+/turf/closed/wall,
 /area/station/hallway/primary/tram/center)
 "gmq" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -21889,6 +21895,9 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
 "gDU" = (
@@ -21912,19 +21921,18 @@
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
 "gEC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door_buttons/airlock_controller{
-	name = "External Access Console";
-	pixel_y = 24;
-	idSelf = "middleright_upper_eva_airlock_control";
-	idInterior = "middleright_upper_eva_internal";
-	idExterior = "middleright_upper_eva_external"
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/railing/corner/end{
 	dir = 4
 	},
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/center)
+/obj/structure/railing/corner/end/flip{
+	dir = 8
+	},
+/turf/open/openspace,
+/area/station/asteroid)
 "gEK" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access"
@@ -23263,11 +23271,11 @@
 "heY" = (
 /obj/effect/turf_decal/siding/thinplating,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "hfd" = (
@@ -23975,7 +23983,6 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
-/obj/machinery/newscaster/directional/west,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
@@ -25962,11 +25969,11 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "ifS" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
-	dir = 9
+	dir = 4
 	},
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/left)
 "ifU" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -26265,16 +26272,10 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "imm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/structure/disposalpipe/trunk/multiz{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/port/central)
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall,
+/area/station/hallway/primary/tram/center)
 "imn" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -27216,12 +27217,9 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "iFH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/dim/directional/east,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/port/central)
+/obj/structure/stairs/south,
+/turf/open/floor/plating,
+/area/station/maintenance/tram/left)
 "iFP" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -28185,12 +28183,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/right)
 "iYd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/newscaster/directional/north,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
 	},
-/obj/machinery/light/small/dim/directional/north,
-/turf/open/floor/catwalk_floor,
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/left)
 "iYv" = (
 /obj/structure/chair/office/light{
@@ -28315,18 +28312,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/lab)
-"iZK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/structure/disposalpipe/trunk/multiz/down{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/left)
 "iZL" = (
 /obj/structure/chair/stool/bar/directional/east,
 /obj/structure/cable,
@@ -28886,12 +28871,7 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/drone_bay)
 "jjl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/small/dim/directional/south,
-/turf/open/floor/catwalk_floor,
+/turf/closed/wall/rust,
 /area/station/hallway/primary/tram/right)
 "jjy" = (
 /obj/structure/table,
@@ -29293,13 +29273,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "jpR" = (
-/obj/structure/cable/multilayer/multiz,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/structure/railing{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/port/central)
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/openspace,
+/area/station/asteroid)
 "jpV" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -29411,12 +29393,15 @@
 /area/station/commons/dorms)
 "jrz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/dim/directional/north,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/trimline/white/warning{
+	dir = 1
 	},
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/center)
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/effect/turf_decal/arrows,
+/turf/open/floor/iron,
+/area/station/maintenance/tram/left)
 "jrI" = (
 /obj/structure/disposalpipe/trunk/multiz{
 	dir = 4
@@ -31604,12 +31589,13 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
 "kcA" = (
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/end,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/port/central)
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/iron/stairs/right{
+	dir = 1
+	},
+/area/station/maintenance/tram/left)
 "kcB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
@@ -31694,14 +31680,20 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "kdd" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Emergency Exit"
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/catwalk_floor,
+/obj/machinery/door/airlock/public/glass{
+	name = "West Wing"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/left)
 "kdr" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -31720,14 +31712,22 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "kdz" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Emergency Exit"
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/catwalk_floor,
+/obj/machinery/door/airlock/public/glass{
+	name = "East Wing"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/right)
 "kdI" = (
 /obj/structure/cable,
@@ -31802,7 +31802,9 @@
 /turf/open/floor/circuit/green,
 /area/station/ai/upload/chamber)
 "keN" = (
-/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
 "keQ" = (
@@ -32577,26 +32579,14 @@
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
 "krh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	frequency = 1449;
-	id_tag = "middleright_upper_eva_internal";
-	autoclose = 0
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
 	},
-/obj/machinery/door_buttons/access_button{
-	name = "External Access Button";
-	pixel_y = -24;
-	idSelf = "middleright_upper_eva_airlock_control";
-	idDoor = "middleright_upper_eva_internal"
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/center)
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
 "krk" = (
 /obj/structure/floodlight_frame,
 /obj/machinery/light/directional/north,
@@ -32653,6 +32643,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
 "krV" = (
@@ -32660,8 +32651,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 1
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
@@ -34284,10 +34275,20 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "kSI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/dim/directional/south,
+/obj/machinery/door/airlock/public/glass{
+	name = "East Wing"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 4
+	},
 /turf/open/floor/iron/smooth,
-/area/station/hallway/primary/tram/center)
+/area/station/hallway/primary/tram/right)
 "kSL" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
@@ -34676,18 +34677,13 @@
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "kYk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door_buttons/airlock_controller{
-	name = "External Access Console";
-	pixel_y = 24;
-	idSelf = "rightmost_upper_eva_airlock_control";
-	idInterior = "rightmost_upper_eva_internal";
-	idExterior = "rightmost_upper_eva_external"
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 10
 	},
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/right)
 "kYL" = (
 /obj/effect/spawner/random/structure/closet_private,
@@ -34979,7 +34975,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "leX" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4
 	},
@@ -34989,7 +34984,10 @@
 /obj/effect/mapping_helpers/mail_sorting/medbay/general,
 /obj/effect/mapping_helpers/mail_sorting/medbay/virology,
 /obj/machinery/light/small/dim/directional/north,
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "lfq" = (
 /obj/effect/turf_decal/trimline/white/warning{
@@ -35078,7 +35076,11 @@
 /area/station/commons/lounge)
 "lgK" = (
 /obj/structure/railing,
-/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/ladder,
 /turf/open/openspace,
 /area/station/asteroid)
 "lgO" = (
@@ -35540,9 +35542,20 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock/cafeteria)
 "loc" = (
-/obj/structure/sign/warning/electric_shock,
-/turf/closed/wall,
-/area/station/hallway/primary/tram/left)
+/obj/machinery/door/airlock/public/glass{
+	name = "East Wing"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/station/hallway/primary/tram/right)
 "lof" = (
 /obj/item/toy/balloon,
 /turf/open/floor/eighties/red,
@@ -35902,7 +35915,10 @@
 /area/station/medical/medbay/central)
 "ltd" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "ltl" = (
 /obj/structure/cable,
@@ -36213,24 +36229,22 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "lyt" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	frequency = 1449;
-	id_tag = "rightmost_upper_eva_external";
-	autoclose = 0
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door_buttons/access_button{
-	name = "External Access Button";
-	pixel_y = 24;
-	idSelf = "rightmost_upper_eva_airlock_control";
-	idDoor = "rightmost_upper_eva_external"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/catwalk_floor,
+/obj/machinery/door/airlock/public/glass{
+	name = "East Wing"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/right)
 "lyx" = (
 /obj/structure/table,
@@ -36668,11 +36682,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/obj/effect/mapping_helpers/mail_sorting/service/library,
-/obj/effect/mapping_helpers/mail_sorting/service/chapel,
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/left)
 "lFw" = (
@@ -36692,14 +36704,19 @@
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "lGp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/light/dim/directional/south,
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/left)
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable/multilayer/multiz,
+/obj/structure/disposalpipe/trunk/multiz{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/port/central)
 "lGu" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
@@ -36806,25 +36823,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/lower)
 "lIQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	frequency = 1449;
-	id_tag = "mostleft_upper_eva_internal";
-	autoclose = 0
-	},
-/obj/machinery/door_buttons/access_button{
-	name = "External Access Button";
-	pixel_y = 24;
-	idSelf = "mostleft_upper_eva_airlock_control";
-	idDoor = "mostleft_upper_eva_internal"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/left)
+/obj/effect/turf_decal/sand/plating,
+/obj/structure/ladder,
+/turf/open/floor/plating,
+/area/station/asteroid)
 "lIR" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Hallway - Upper East Power Hatch"
@@ -37310,8 +37312,8 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "lRs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/ladder,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/right)
 "lRx" = (
@@ -37596,12 +37598,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "lVe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
 	},
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/right)
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
 "lVi" = (
 /turf/closed/wall,
 /area/station/maintenance/department/science)
@@ -38326,21 +38327,19 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "mhE" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	frequency = 1449;
-	id_tag = "middleright_lower_eva_external";
-	autoclose = 0
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Wing"
 	},
-/obj/machinery/door_buttons/access_button{
-	name = "External Access Button";
-	pixel_y = -24;
-	idSelf = "middleright_lower_eva_airlock_control";
-	idDoor = "middleright_lower_eva_external"
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/plating,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "mhJ" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
@@ -38417,6 +38416,14 @@
 	dir = 1
 	},
 /obj/machinery/newscaster/directional/north,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/mail_sorting/service/chapel,
+/obj/effect/mapping_helpers/mail_sorting/service/library,
+/obj/machinery/camera/directional/north{
+	c_tag = "Civilian - Recreational Area North-West"
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "mjF" = (
@@ -39105,11 +39112,11 @@
 /turf/open/floor/iron/checker,
 /area/station/commons/lounge)
 "mzf" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
-	dir = 5
+	dir = 4
 	},
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/right)
 "mzg" = (
 /obj/effect/decal/cleanable/dirt,
@@ -39552,13 +39559,12 @@
 /turf/open/floor/iron/checker,
 /area/station/commons/lounge)
 "mHj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/light/small/dim/directional/south,
-/turf/open/floor/catwalk_floor,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "mHt" = (
 /obj/machinery/door/airlock/engineering{
@@ -41631,6 +41637,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/east,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
 "nvA" = (
@@ -41991,22 +41998,9 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "nAT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	frequency = 1449;
-	id_tag = "middleleft_lower_eva_internal";
-	autoclose = 0
-	},
-/obj/machinery/door_buttons/access_button{
-	name = "External Access Button";
-	pixel_y = 24;
-	idSelf = "middleleft_lower_eva_airlock_control";
-	idDoor = "middleleft_lower_eva_internal"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/center)
+/obj/structure/ladder,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/tram/right)
 "nBg" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
@@ -42556,6 +42550,9 @@
 	},
 /obj/item/kirbyplants/random,
 /obj/structure/sign/poster/official/random/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "nMX" = (
@@ -42598,7 +42595,6 @@
 /area/station/hallway/primary/tram/right)
 "nNs" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/ladder,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/tram/mid)
 "nNz" = (
@@ -42643,12 +42639,9 @@
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "nOo" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Tram Mechanical Room"
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/unres/delayed{
-	dir = 4
+/obj/machinery/door/airlock/hatch{
+	name = "Tram Mechanical Room"
 	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/tram/right)
@@ -43143,7 +43136,6 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "nXn" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -43783,7 +43775,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "ojT" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/left)
 "ojU" = (
@@ -43945,7 +43941,6 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "onf" = (
-/obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 6
 	},
@@ -44177,10 +44172,12 @@
 /turf/open/floor/glass/reinforced,
 /area/station/security/warden)
 "osG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/ladder,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/smooth,
-/area/station/maintenance/tram/right)
+/area/station/hallway/primary/tram/center)
 "osN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/engine,
@@ -44555,6 +44552,9 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/right)
 "oBc" = (
@@ -44665,9 +44665,11 @@
 /area/station/engineering/supermatter/room)
 "oDs" = (
 /obj/structure/cable,
-/obj/item/radio/intercom/directional/west,
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
@@ -45073,7 +45075,9 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/obj/structure/railing,
+/obj/structure/ladder,
 /turf/open/openspace,
 /area/station/asteroid)
 "oNJ" = (
@@ -45711,15 +45715,20 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "pal" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/machinery/door/airlock/public/glass{
+	name = "West Wing"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/port/central)
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/station/hallway/primary/tram/left)
 "pam" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -45782,10 +45791,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "pbC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/ladder,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/light/warm/directional/north,
 /turf/open/floor/iron/smooth,
-/area/station/hallway/primary/tram/center)
+/area/station/hallway/primary/tram/right)
 "pbH" = (
 /turf/closed/wall/r_wall,
 /area/station/science/server)
@@ -47292,11 +47303,10 @@
 /turf/open/floor/plating,
 /area/station/science/ordnance/storage)
 "pBj" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "pBp" = (
@@ -49744,11 +49754,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/vacant_room)
 "qtS" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "qtV" = (
 /obj/effect/turf_decal/caution/stand_clear/white{
@@ -50172,10 +50182,10 @@
 "qCf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/port/central)
 "qCk" = (
@@ -50437,25 +50447,15 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "qHo" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	frequency = 1449;
-	id_tag = "rightmost_upper_eva_internal";
-	autoclose = 0
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door_buttons/access_button{
-	name = "External Access Button";
-	pixel_y = 24;
-	idSelf = "rightmost_upper_eva_airlock_control";
-	idDoor = "rightmost_upper_eva_internal"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/right)
+/obj/structure/railing/corner/end{
+	dir = 8
+	},
+/turf/open/openspace,
+/area/station/asteroid)
 "qHs" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
@@ -50534,12 +50534,11 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/arrivals)
 "qIt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
 	},
-/obj/machinery/light/small/dim/directional/north,
-/turf/open/floor/catwalk_floor,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/right)
 "qIA" = (
 /obj/machinery/light/directional/south,
@@ -51044,9 +51043,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "qSQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/dim/directional/south,
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/left)
 "qSS" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -51126,12 +51124,9 @@
 /area/station/engineering/atmos)
 "qUg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/left)
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/tram/left)
 "qUk" = (
 /obj/effect/turf_decal/tile/neutral/tram,
 /turf/open/indestructible/tram/plate,
@@ -52245,10 +52240,10 @@
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/hos)
 "rmH" = (
-/obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 10
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/right)
 "rmI" = (
@@ -52336,10 +52331,18 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "rnR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/left)
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing/corner/end/flip{
+	dir = 8
+	},
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/turf/open/openspace,
+/area/station/asteroid)
 "rnY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
@@ -52430,21 +52433,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
 "roH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	frequency = 1449;
-	id_tag = "middleright_lower_eva_internal";
-	autoclose = 0
-	},
-/obj/machinery/door_buttons/access_button{
-	name = "External Access Button";
-	pixel_y = 24;
-	idSelf = "middleright_lower_eva_airlock_control";
-	idDoor = "middleright_lower_eva_internal"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/catwalk_floor,
+/obj/machinery/light/warm/directional/south,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "roQ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -52915,7 +52906,11 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "rxO" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/right)
 "rxU" = (
@@ -53711,6 +53706,7 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/girder/displaced,
 /turf/open/floor/iron,
 /area/station/maintenance/tram/left)
 "rOr" = (
@@ -53974,12 +53970,12 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "rRK" = (
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/end,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/hallway/primary/tram/left)
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/corner/end/flip{
+	dir = 8
+	},
+/turf/open/openspace,
+/area/station/asteroid)
 "rSa" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -54037,6 +54033,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
 "rSp" = (
@@ -54091,8 +54088,8 @@
 "rTn" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "rTt" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -54637,15 +54634,22 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "seG" = (
-/obj/structure/ladder,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/station/hallway/primary/tram/center)
+/obj/structure/lattice/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/railing/corner/end/flip{
+	dir = 4
+	},
+/turf/open/openspace,
+/area/station/asteroid)
 "seN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/dim/directional/north,
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/right)
+/obj/machinery/light/warm/directional/north,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/station/hallway/primary/tram/left)
 "seQ" = (
 /obj/machinery/flasher/directional/west{
 	id = "AI"
@@ -55571,7 +55575,9 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "stO" = (
-/obj/structure/ladder,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/tram/right)
@@ -55845,22 +55851,10 @@
 /turf/open/floor/carpet,
 /area/station/cargo/miningdock)
 "syX" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Tram Mechanical Room"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/unres/delayed{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/left)
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/turf/open/floor/iron/smooth,
+/area/station/hallway/primary/tram/center)
 "szb" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -56297,15 +56291,23 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "sIk" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Emergency Exit"
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/catwalk_floor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Wing"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "sIx" = (
 /obj/structure/lattice/catwalk,
@@ -56914,6 +56916,7 @@
 /area/station/science/lobby)
 "sUc" = (
 /obj/structure/ladder,
+/obj/machinery/light/dim/directional/south,
 /turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/right)
 "sUf" = (
@@ -57439,18 +57442,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "tdu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door_buttons/airlock_controller{
-	name = "External Access Console";
-	pixel_y = 24;
-	idSelf = "mostleft_upper_eva_airlock_control";
-	idInterior = "mostleft_upper_eva_internal";
-	idExterior = "mostleft_upper_eva_external"
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 6
 	},
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/left)
 "tdx" = (
 /turf/closed/wall,
@@ -57487,15 +57485,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "tel" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/left)
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/machinery/light/warm/directional/south,
+/turf/open/floor/iron/smooth,
+/area/station/hallway/primary/tram/right)
 "teo" = (
 /obj/structure/chair{
 	dir = 8
@@ -57618,6 +57611,9 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
@@ -57813,8 +57809,8 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/vacant_room)
 "tkv" = (
-/obj/structure/ladder,
-/obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/left)
 "tkH" = (
@@ -58039,11 +58035,12 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "toT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/dim/directional/north,
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/left)
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/corner/end/flip{
+	dir = 4
+	},
+/turf/open/openspace,
+/area/station/asteroid)
 "tpm" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -58829,21 +58826,19 @@
 /turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "tBu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	frequency = 1449;
-	id_tag = "mostleft_lower_eva_external";
-	autoclose = 0
+/obj/machinery/door/airlock/public/glass{
+	name = "West Wing"
 	},
-/obj/machinery/door_buttons/access_button{
-	name = "External Access Button";
-	pixel_y = -24;
-	idSelf = "mostleft_lower_eva_airlock_control";
-	idDoor = "mostleft_lower_eva_external"
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/catwalk_floor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/left)
 "tBv" = (
 /obj/structure/disposalpipe/segment{
@@ -59101,10 +59096,14 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "tFW" = (
-/obj/structure/ladder,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/port/central)
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/firealarm_sanity,
+/turf/open/floor/iron/stairs/right{
+	dir = 1
+	},
+/area/station/maintenance/tram/left)
 "tGc" = (
 /obj/structure/closet/secure_closet/brig/genpop,
 /obj/effect/turf_decal/bot,
@@ -59143,8 +59142,14 @@
 /turf/open/floor/iron,
 /area/station/escapepodbay)
 "tHj" = (
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/center)
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
 "tHt" = (
 /obj/structure/railing{
 	dir = 1
@@ -59555,9 +59560,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
 "tOJ" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "tOQ" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -59664,15 +59669,7 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "tRn" = (
-/obj/structure/table,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Civilian - Recreational Area North-West"
-	},
-/obj/item/toy/plush/lizard_plushie/space/green,
-/obj/machinery/incident_display/tram/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "tRo" = (
@@ -60668,15 +60665,10 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "ujs" = (
-/obj/effect/turf_decal/siding/thinplating,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation)
+/obj/machinery/light/warm/directional/south,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/turf/open/floor/iron/smooth,
+/area/station/hallway/primary/tram/left)
 "ujt" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters/window{
@@ -61153,7 +61145,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "uqa" = (
-/obj/machinery/newscaster/directional/west,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
 "uqc" = (
@@ -61680,8 +61674,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "uyd" = (
-/obj/structure/table,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/structure/table,
+/obj/item/pai_card,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "uyf" = (
@@ -62153,10 +62148,9 @@
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "uFD" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/left)
 "uFE" = (
@@ -64640,6 +64634,9 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/right)
 "vvk" = (
@@ -64735,7 +64732,6 @@
 /turf/open/space/openspace,
 /area/station/solars/starboard/fore)
 "vwT" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -65569,24 +65565,22 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "vMI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	frequency = 1449;
-	id_tag = "middleleft_upper_eva_external";
-	autoclose = 0
-	},
-/obj/machinery/door_buttons/access_button{
-	name = "External Access Button";
-	pixel_y = 24;
-	idSelf = "middleleft_upper_eva_airlock_control";
-	idDoor = "middleleft_upper_eva_external"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/catwalk_floor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Wing"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "vMJ" = (
 /obj/structure/cable,
@@ -66233,11 +66227,14 @@
 /turf/open/floor/iron/dark,
 /area/station/command/vault)
 "vYA" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "vYD" = (
 /obj/structure/railing{
@@ -67033,11 +67030,19 @@
 /turf/open/floor/plating,
 /area/station/engineering/engine_smes)
 "wnP" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Emergency Exit"
+/obj/machinery/door/airlock/public/glass{
+	name = "East Wing"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/right)
 "woB" = (
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -67688,9 +67693,19 @@
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/foyer)
 "wzJ" = (
-/obj/structure/sign/warning/electric_shock,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/port/central)
+/obj/structure/lattice/catwalk,
+/obj/structure/railing,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/railing/corner/end{
+	dir = 8
+	},
+/obj/structure/railing/corner/end/flip{
+	dir = 4
+	},
+/turf/open/openspace,
+/area/station/asteroid)
 "wAa" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -68011,7 +68026,10 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "wFq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -68529,6 +68547,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
 "wQl" = (
@@ -68585,11 +68606,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction/engineering)
 "wRu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/catwalk_floor,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "wRv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
@@ -68752,18 +68774,19 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit)
 "wWn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door_buttons/airlock_controller{
-	name = "External Access Console";
-	pixel_y = 24;
-	idSelf = "middleleft_upper_eva_airlock_control";
-	idInterior = "middleleft_upper_eva_internal";
-	idExterior = "middleleft_upper_eva_external"
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Wing"
 	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 4
 	},
-/turf/open/floor/catwalk_floor,
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "wWu" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -68868,7 +68891,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wYw" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "wYE" = (
@@ -68959,6 +68983,9 @@
 	},
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
 "xat" = (
@@ -69049,11 +69076,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "xbT" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/right)
@@ -69554,9 +69581,8 @@
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "xlZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/dim/directional/south,
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "xml" = (
 /obj/effect/turf_decal/loading_area{
@@ -69922,7 +69948,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "xts" = (
@@ -70113,11 +70141,19 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "xwO" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Emergency Exit"
+/obj/machinery/door/airlock/public/glass{
+	name = "West Wing"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/left)
 "xxe" = (
 /obj/machinery/duct,
@@ -70410,11 +70446,10 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/oresilo)
 "xBV" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/structure/disposalpipe/junction/flip{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -70497,6 +70532,7 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "xEZ" = (
+/obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/station/hallway/secondary/exit)
@@ -87330,10 +87366,10 @@ pZW
 pZW
 pZW
 pZW
-lQM
-lQM
-lQM
-lQM
+pZW
+pZW
+pZW
+pZW
 dIy
 pZW
 pZW
@@ -87586,11 +87622,11 @@ qQq
 qQq
 qQq
 qQq
-qQq
-lQM
-jpR
-imm
-wzJ
+qUg
+jrz
+kcA
+iFH
+pZW
 dIy
 pZW
 tUM
@@ -87844,10 +87880,10 @@ qQq
 qQq
 qQq
 qQq
-lQM
+jrz
 tFW
-pal
-cYe
+iFH
+pZW
 qCf
 pZW
 uof
@@ -88101,11 +88137,11 @@ agL
 qQq
 qQq
 qQq
-lQM
+jrz
 kcA
 iFH
-lQM
-jAk
+pZW
+lGp
 pZW
 elr
 elr
@@ -88357,11 +88393,11 @@ xZV
 qQq
 qQq
 qQq
-xZV
-lQM
-lQM
-lQM
-lQM
+qQq
+fnL
+ncF
+ncF
+pZW
 pZW
 pZW
 kNn
@@ -96576,13 +96612,13 @@ aaa
 abM
 acx
 vFt
-acx
+lIQ
 abM
 abM
 ada
 abM
 abM
-acx
+lIQ
 yiM
 acx
 abM
@@ -98375,13 +98411,13 @@ abM
 abM
 acx
 izU
-acx
+lIQ
 abM
 abM
 ada
 abM
 abM
-acx
+lIQ
 qas
 acx
 abM
@@ -101458,7 +101494,7 @@ qtV
 ceb
 qjU
 vqx
-ecX
+nNs
 qjU
 acQ
 acQ
@@ -107120,7 +107156,7 @@ adc
 acP
 acP
 qjU
-ecX
+nNs
 bXs
 qjU
 aaa
@@ -110197,13 +110233,13 @@ abM
 abM
 acx
 qas
-acx
+lIQ
 abM
 abM
 ada
 abM
 abM
-acx
+lIQ
 izU
 acx
 abM
@@ -111996,13 +112032,13 @@ abM
 abM
 acx
 bMb
-acx
+lIQ
 abM
 abM
 ada
 abM
 abM
-acx
+lIQ
 bMb
 acx
 abM
@@ -115078,7 +115114,7 @@ whL
 aaa
 aaa
 mbJ
-osG
+hKj
 pqU
 mbJ
 acQ
@@ -115088,7 +115124,7 @@ acQ
 acQ
 mbJ
 fLJ
-osG
+hKj
 mbJ
 aaa
 aaa
@@ -120223,7 +120259,7 @@ nOo
 myD
 myD
 glv
-myD
+aEP
 myD
 myD
 myD
@@ -120737,7 +120773,7 @@ sVq
 myD
 rOB
 aHO
-hKj
+nAT
 aCe
 reU
 myD
@@ -152867,8 +152903,8 @@ jvf
 fKO
 hHA
 jvf
-tPE
-tPE
+jNb
+jNb
 tPE
 cUL
 nXn
@@ -153124,9 +153160,9 @@ cOE
 mHX
 jtg
 jvf
-fnL
-iZK
-yiM
+tDT
+tDT
+krh
 pBj
 nXn
 lUf
@@ -153381,12 +153417,12 @@ qit
 qIN
 lfW
 jvf
-tkv
-lGp
-yiM
+tDT
+tDT
+lVe
 tRn
 nXn
-lUf
+aHe
 cSr
 cSr
 cSr
@@ -153638,9 +153674,9 @@ nXI
 aGh
 cKd
 jvf
-rRK
-tel
-yiM
+tDT
+tDT
+tHj
 brf
 cXc
 lVz
@@ -153895,8 +153931,8 @@ jvf
 fKO
 onT
 jvf
-loc
-syX
+nyM
+nyM
 yiM
 mjx
 heY
@@ -154156,7 +154192,7 @@ szw
 cEg
 yiM
 nMW
-heY
+gpH
 kGA
 tDT
 tDT
@@ -154413,7 +154449,7 @@ dOb
 lFl
 nzH
 xtn
-ujs
+gpH
 kGA
 tDT
 tDT
@@ -158512,7 +158548,7 @@ oTq
 tlg
 kOE
 yiM
-yiM
+xwO
 kdd
 yiM
 cFs
@@ -158522,7 +158558,7 @@ jGG
 cFs
 yiM
 xwO
-yiM
+aEv
 yiM
 fpg
 gyz
@@ -158769,7 +158805,7 @@ ihu
 pUJ
 udY
 yiM
-ojT
+aGL
 drW
 yiM
 wgh
@@ -158778,8 +158814,8 @@ vfD
 dRL
 wgh
 yiM
-toT
-ojT
+aGL
+qSQ
 yiM
 sjN
 heD
@@ -159026,16 +159062,16 @@ hBf
 pkk
 sDe
 yiM
-tkv
-qUg
-yiM
+aGL
+ifS
+iPy
 cFs
 nVr
 laU
 jGG
 cFs
-yiM
-rnR
+iPy
+aGL
 tkv
 yiM
 nyM
@@ -159283,17 +159319,17 @@ aCS
 pIl
 gdF
 yiM
-yiM
-lIQ
-yiM
+seN
+ifS
+iPy
 cFs
 nVr
 laU
 jGG
 cFs
-yiM
+iPy
 aGL
-yiM
+ujs
 yiM
 cFs
 cFs
@@ -159542,14 +159578,14 @@ dUl
 yiM
 iYd
 ifS
-yiM
+iPy
 cFs
 nVr
 laU
 jGG
 cFs
-yiM
-aEP
+iPy
+aGL
 qSQ
 yiM
 cFs
@@ -159799,15 +159835,15 @@ rPH
 yiM
 tdu
 ojT
-iPy
+yiM
 cFs
 lNP
 laU
 jGG
 cFs
-iPy
-ojT
-aHe
+yiM
+cYe
+qSQ
 yiM
 cFs
 cFs
@@ -160055,7 +160091,7 @@ urP
 kOE
 yiM
 aEh
-iPy
+tBu
 yiM
 cFs
 nVr
@@ -160063,7 +160099,7 @@ laU
 jGG
 cFs
 yiM
-iPy
+pal
 tBu
 yiM
 yiM
@@ -160311,8 +160347,8 @@ aaS
 aaS
 aaS
 afz
-afA
-afz
+seG
+aHo
 mtY
 taP
 hpt
@@ -160320,8 +160356,8 @@ tED
 rvH
 taP
 byy
-afz
-age
+toT
+aHo
 abM
 afg
 abW
@@ -160569,7 +160605,7 @@ abW
 abM
 afy
 afA
-afy
+age
 afy
 cFs
 nVr
@@ -160577,7 +160613,7 @@ laU
 jGG
 cFs
 afy
-afy
+agg
 age
 afy
 afg
@@ -160826,7 +160862,7 @@ abW
 abS
 afy
 afA
-afy
+age
 afy
 cFs
 nVr
@@ -160834,7 +160870,7 @@ laU
 jGG
 cFs
 afy
-afy
+agg
 age
 afy
 acm
@@ -161083,7 +161119,7 @@ afg
 afy
 afy
 afA
-afy
+age
 afy
 cFs
 nVr
@@ -161091,7 +161127,7 @@ laU
 jGG
 cFs
 afy
-afy
+agg
 age
 afy
 abW
@@ -161340,7 +161376,7 @@ afg
 abS
 afy
 afA
-afy
+age
 afy
 cFs
 nVr
@@ -161348,7 +161384,7 @@ laU
 jGG
 cFs
 afy
-afy
+agg
 age
 afy
 afy
@@ -161597,7 +161633,7 @@ acm
 abS
 afy
 afA
-afy
+age
 afy
 cFs
 nVr
@@ -161605,7 +161641,7 @@ laU
 jGG
 cFs
 afy
-afy
+agg
 age
 afy
 afy
@@ -161862,7 +161898,7 @@ laU
 jGG
 cFs
 agb
-afE
+jpR
 agf
 afy
 afy
@@ -162110,7 +162146,7 @@ abS
 abW
 afv
 afz
-afC
+wzJ
 vFt
 oNG
 cFs
@@ -162120,7 +162156,7 @@ usE
 cFs
 lgK
 yiM
-agg
+rnR
 afz
 afz
 afv
@@ -162368,7 +162404,7 @@ acm
 afg
 afy
 afD
-afG
+bly
 afM
 cFs
 nVr
@@ -162625,7 +162661,7 @@ abS
 afo
 afy
 afA
-afy
+age
 afy
 cFs
 nVr
@@ -162633,7 +162669,7 @@ laU
 jGG
 cFs
 afy
-afy
+agg
 age
 afy
 abW
@@ -162882,7 +162918,7 @@ abS
 afo
 afy
 afA
-afy
+age
 afy
 cFs
 nVr
@@ -162890,7 +162926,7 @@ laU
 jGG
 cFs
 afy
-afy
+agg
 age
 afy
 afo
@@ -163139,7 +163175,7 @@ acm
 afo
 afy
 afA
-afy
+age
 afy
 eSz
 nSP
@@ -163147,7 +163183,7 @@ fXy
 lwN
 eSz
 afy
-afy
+agg
 age
 afy
 abS
@@ -163396,7 +163432,7 @@ acm
 abW
 afy
 afA
-afy
+age
 afy
 eSz
 nSP
@@ -163404,7 +163440,7 @@ fXy
 lwN
 eSz
 afy
-afy
+agg
 age
 afy
 abW
@@ -163661,7 +163697,7 @@ fXy
 lwN
 eSz
 agb
-afE
+jpR
 agf
 afy
 afg
@@ -163919,7 +163955,7 @@ aKC
 eSz
 lgK
 qas
-agg
+gEC
 afz
 afv
 abW
@@ -164167,8 +164203,8 @@ abW
 afy
 afy
 afD
-afG
-afN
+bly
+afM
 eSz
 nSP
 fXy
@@ -164424,7 +164460,7 @@ abS
 abW
 afy
 afA
-afy
+age
 afy
 eSz
 nSP
@@ -164432,7 +164468,7 @@ fXy
 lwN
 eSz
 afy
-afy
+agg
 age
 afy
 abW
@@ -164681,7 +164717,7 @@ afo
 abS
 afy
 afA
-afy
+age
 afy
 eSz
 nSP
@@ -164689,7 +164725,7 @@ fXy
 lwN
 eSz
 afy
-afy
+agg
 age
 afy
 abW
@@ -164938,7 +164974,7 @@ abW
 abW
 afy
 afA
-afy
+age
 afy
 eSz
 nSP
@@ -164946,7 +164982,7 @@ fXy
 lwN
 eSz
 afy
-afy
+agg
 age
 afy
 abS
@@ -165195,7 +165231,7 @@ abM
 abM
 afy
 afA
-afy
+age
 afy
 eSz
 nSP
@@ -165203,7 +165239,7 @@ fXy
 lwN
 eSz
 afy
-afy
+agg
 age
 afy
 abW
@@ -165452,7 +165488,7 @@ aaa
 abM
 afy
 afA
-afy
+age
 afy
 eSz
 nSP
@@ -165460,7 +165496,7 @@ fXy
 lwN
 eSz
 afy
-afy
+agg
 age
 afy
 abW
@@ -165708,8 +165744,8 @@ aaa
 aaa
 afv
 afz
-afA
-afz
+qHo
+rRK
 sbs
 ryn
 cZX
@@ -165717,8 +165753,8 @@ eXw
 nnA
 ryn
 eGX
-afz
-age
+aHl
+rRK
 afz
 afv
 aaa
@@ -165966,7 +166002,7 @@ izU
 izU
 izU
 vMI
-nEl
+dnp
 izU
 eSz
 nSP
@@ -165974,7 +166010,7 @@ fXy
 lwN
 eSz
 izU
-nEl
+afN
 dnp
 izU
 aaa
@@ -166222,17 +166258,17 @@ eSz
 eSz
 eSz
 izU
-wWn
+clO
 wYw
-nEl
+izU
 eSz
 nSP
 fXy
 lwN
 eSz
-nEl
-wYw
-aHf
+izU
+osG
+xlZ
 izU
 aaa
 aaa
@@ -166479,17 +166515,17 @@ eSz
 eSz
 eSz
 izU
-vYA
-kSI
-izU
+clO
+xlZ
+nEl
 eSz
 nSP
 fXy
 lwN
 eSz
-izU
+nEl
 ccU
-ghg
+syX
 jyH
 jyH
 jyH
@@ -166737,16 +166773,16 @@ eSz
 eSz
 izU
 dEH
-izU
-izU
+xlZ
+nEl
 eSz
 nSP
 fXy
 lwN
 eSz
-izU
-izU
-nAT
+nEl
+ccU
+roH
 jyH
 lCA
 jRS
@@ -166994,16 +167030,16 @@ nHM
 fnb
 izU
 vYA
-seG
-izU
+xlZ
+nEl
 eSz
 nSP
 fXy
 lwN
 eSz
-izU
-seG
-tHj
+nEl
+ccU
+xlZ
 jyH
 pvp
 kSh
@@ -167252,7 +167288,7 @@ crQ
 izU
 leX
 rTn
-gmm
+imm
 lEj
 rWQ
 iCj
@@ -167508,7 +167544,7 @@ rOu
 xCp
 izU
 sIk
-izU
+mhE
 izU
 eSz
 nSP
@@ -167516,7 +167552,7 @@ fXy
 lwN
 eSz
 izU
-izU
+wWn
 dMw
 jyH
 wmy
@@ -172133,8 +172169,8 @@ lZW
 lZW
 izU
 izU
-fVN
-izU
+vMI
+dnp
 izU
 eSz
 nSP
@@ -172142,7 +172178,7 @@ fXy
 lwN
 eSz
 izU
-izU
+afN
 fVN
 izU
 wza
@@ -172648,15 +172684,15 @@ aaa
 aaa
 izU
 clO
-pbC
-izU
+xlZ
+nEl
 eSz
 nSP
 fXy
 lwN
 eSz
-izU
-seG
+nEl
+ccU
 dCJ
 izU
 wza
@@ -172904,16 +172940,16 @@ aaa
 aaa
 aaa
 izU
-krh
-izU
-izU
+dEH
+xlZ
+nEl
 eSz
 nSP
 fXy
 lwN
 eSz
-izU
-izU
+nEl
+ccU
 roH
 izU
 wza
@@ -173161,16 +173197,16 @@ aaa
 aaa
 aaa
 izU
-jrz
-wYw
-izU
+vYA
+xlZ
+nEl
 eSz
 nSP
 fXy
 lwN
 eSz
-izU
-ghg
+nEl
+ccU
 xlZ
 izU
 wza
@@ -173418,17 +173454,17 @@ aaa
 aaa
 aaa
 izU
-gEC
+clO
 wYw
-nEl
+izU
 eSz
 nSP
 fXy
 lwN
 eSz
-nEl
-wYw
-aHl
+izU
+osG
+xlZ
 izU
 wza
 izU
@@ -173676,7 +173712,7 @@ aaa
 aaa
 izU
 eqK
-nEl
+mhE
 izU
 eSz
 nSP
@@ -173684,7 +173720,7 @@ fXy
 lwN
 eSz
 izU
-nEl
+wWn
 mhE
 izU
 wza
@@ -173932,8 +173968,8 @@ aaa
 aaa
 afv
 afz
-afA
-afz
+seG
+aHo
 mtY
 ryn
 cZX
@@ -173941,8 +173977,8 @@ crg
 nnA
 ryn
 byy
-afz
-age
+toT
+aHo
 aaS
 abM
 aaS
@@ -174190,7 +174226,7 @@ aaa
 afy
 afy
 afA
-afy
+age
 afy
 eSz
 nSP
@@ -174198,7 +174234,7 @@ fXy
 lwN
 eSz
 afy
-afy
+agg
 age
 aaS
 abM
@@ -174447,7 +174483,7 @@ aaa
 afy
 afy
 afA
-afy
+age
 afy
 eSz
 nSP
@@ -174455,7 +174491,7 @@ fXy
 lwN
 eSz
 afy
-afy
+agg
 age
 aaS
 abM
@@ -174704,7 +174740,7 @@ aaa
 afy
 afy
 afA
-afy
+age
 afy
 eSz
 nSP
@@ -174712,7 +174748,7 @@ fXy
 lwN
 eSz
 afy
-afy
+agg
 age
 afy
 aaa
@@ -174961,7 +174997,7 @@ afo
 abS
 afy
 afA
-afy
+age
 afy
 eSz
 nSP
@@ -174969,7 +175005,7 @@ fXy
 lwN
 eSz
 afy
-afy
+agg
 age
 afy
 afy
@@ -175218,7 +175254,7 @@ abS
 abS
 afy
 afA
-afy
+age
 afy
 eSz
 nSP
@@ -175226,7 +175262,7 @@ fXy
 lwN
 eSz
 afy
-afy
+agg
 age
 afy
 afy
@@ -175483,7 +175519,7 @@ fXy
 lwN
 eSz
 agb
-afE
+jpR
 agf
 afy
 afy
@@ -175731,7 +175767,7 @@ aaa
 aaa
 afv
 afz
-afC
+wzJ
 qas
 oNG
 eSz
@@ -175741,7 +175777,7 @@ aKC
 eSz
 lgK
 izU
-agg
+rnR
 afz
 afz
 afv
@@ -175989,8 +176025,8 @@ aaa
 afy
 afy
 afD
-afG
-afN
+bly
+afM
 eSz
 nSP
 fXy
@@ -176246,7 +176282,7 @@ afy
 afy
 afy
 afA
-afy
+age
 afy
 eSz
 nSP
@@ -176254,7 +176290,7 @@ fXy
 lwN
 eSz
 afy
-afy
+agg
 age
 afy
 abW
@@ -176503,7 +176539,7 @@ aaa
 afy
 afy
 afA
-afy
+age
 afy
 eSz
 nSP
@@ -176511,7 +176547,7 @@ fXy
 lwN
 eSz
 afy
-afy
+agg
 age
 afy
 abS
@@ -176760,7 +176796,7 @@ aaa
 afg
 afy
 afA
-afy
+age
 afy
 brm
 gay
@@ -176768,7 +176804,7 @@ lZj
 jwH
 brm
 afy
-afy
+agg
 age
 afy
 abW
@@ -177017,7 +177053,7 @@ abW
 afo
 afy
 afA
-afy
+age
 afy
 brm
 gay
@@ -177025,7 +177061,7 @@ lZj
 jwH
 brm
 afy
-afy
+agg
 age
 afy
 afy
@@ -177282,7 +177318,7 @@ lZj
 jwH
 brm
 agb
-afE
+jpR
 agf
 afy
 afy
@@ -177539,8 +177575,8 @@ lZj
 tSl
 brm
 lgK
-bMb
-agg
+jjl
+gEC
 afz
 afz
 afv
@@ -177788,8 +177824,8 @@ aaa
 afy
 afy
 afD
-afG
-afN
+bly
+afM
 brm
 gay
 lZj
@@ -178045,7 +178081,7 @@ aaa
 afy
 afy
 afA
-afy
+age
 afy
 brm
 gay
@@ -178053,7 +178089,7 @@ kxL
 jwH
 brm
 afy
-afy
+agg
 age
 afy
 afy
@@ -178302,7 +178338,7 @@ afy
 afy
 afy
 afA
-afy
+age
 afy
 brm
 gay
@@ -178310,7 +178346,7 @@ lZj
 jwH
 brm
 afy
-afy
+agg
 age
 afy
 abM
@@ -178559,7 +178595,7 @@ afy
 afy
 afy
 afA
-afy
+age
 afy
 brm
 gay
@@ -178567,7 +178603,7 @@ lZj
 jwH
 brm
 afy
-afy
+agg
 age
 afy
 aaS
@@ -178816,7 +178852,7 @@ afy
 abM
 afy
 afA
-afy
+age
 afy
 brm
 gay
@@ -178824,7 +178860,7 @@ lZj
 jwH
 brm
 afy
-afy
+agg
 age
 aaS
 aaS
@@ -179073,7 +179109,7 @@ aaa
 abM
 afy
 afA
-afy
+age
 afy
 brm
 gay
@@ -179081,7 +179117,7 @@ lZj
 jwH
 brm
 afy
-afy
+agg
 age
 aaS
 abM
@@ -179329,8 +179365,8 @@ aaa
 aaa
 afv
 afz
-afA
-afz
+qHo
+rRK
 sbs
 ksH
 ngN
@@ -179338,8 +179374,8 @@ iDQ
 oFV
 ksH
 eGX
-afz
-age
+aHl
+rRK
 aaS
 abM
 soq
@@ -179587,7 +179623,7 @@ aaa
 aaa
 bMb
 lyt
-ghV
+bXG
 bMb
 brm
 gay
@@ -179595,7 +179631,7 @@ lZj
 jwH
 brm
 bMb
-ghV
+loc
 bXG
 lVi
 abM
@@ -179845,14 +179881,14 @@ abM
 lZW
 kYk
 rxO
-ghV
+bMb
 brm
 gay
 lZj
 jwH
 brm
-ghV
-rxO
+bMb
+dJk
 aHn
 lVi
 abM
@@ -180102,15 +180138,15 @@ abM
 lZW
 qIt
 mzf
-bMb
+ghV
 brm
 gay
 lZj
 jwH
 brm
-bMb
+ghV
 gaH
-bly
+aHn
 lVi
 abM
 soq
@@ -180357,17 +180393,17 @@ usY
 usY
 abM
 lZW
-bMb
-qHo
-bMb
+pbC
+mzf
+ghV
 brm
 gay
 lZj
 jwH
 brm
-bMb
-aHo
-bMb
+ghV
+gaH
+tel
 lVi
 abM
 soq
@@ -180614,16 +180650,16 @@ tJR
 usY
 abM
 skT
-lRs
-lVe
-bMb
+gaH
+mzf
+ghV
 brm
 gay
 lZj
 jwH
 brm
-bMb
-aEv
+ghV
+gaH
 lRs
 lVi
 abM
@@ -180871,8 +180907,8 @@ jvW
 usY
 usY
 usY
-rxO
-jjl
+gaH
+mzf
 oGM
 nQY
 pTt
@@ -180880,8 +180916,8 @@ nNl
 ryV
 nQY
 sig
-seN
-rxO
+gaH
+aHn
 lVi
 abM
 soq
@@ -181128,7 +181164,7 @@ uYZ
 qlK
 qaH
 vUE
-bMb
+wnP
 kdz
 pxO
 brm
@@ -181138,7 +181174,7 @@ jwH
 brm
 pxO
 wnP
-bMb
+kSI
 lVi
 abM
 soq
@@ -182413,7 +182449,7 @@ wwS
 ged
 whL
 bMb
-rEB
+aHf
 oPw
 rlZ
 brm
@@ -185755,7 +185791,7 @@ mRb
 sYJ
 bMb
 bAj
-dJk
+ftZ
 vUE
 vUE
 ftZ

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -19517,6 +19517,18 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library)
+"fLw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Left Upper Corridor - Central Tram Platform"
+	},
+/turf/open/floor/iron/smooth,
+/area/station/hallway/primary/tram/center)
 "fLB" = (
 /obj/structure/closet/emcloset{
 	anchored = 1
@@ -25912,6 +25924,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"ifi" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/machinery/camera/directional/south{
+	c_tag = "Left Corridor - Port Tram Platform"
+	},
+/turf/open/floor/iron/smooth,
+/area/station/hallway/primary/tram/left)
 "ifk" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8
@@ -31957,6 +31976,15 @@
 /obj/structure/railing,
 /turf/open/space/openspace,
 /area/station/solars/starboard/fore)
+"kho" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Left Upper Corridor - Port Tram Platform"
+	},
+/turf/open/floor/iron/smooth,
+/area/station/hallway/primary/tram/left)
 "khE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -32635,15 +32663,14 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "krM" = (
-/obj/machinery/camera{
-	dir = 6;
-	c_tag = "Hallway - Central Tram Platform South-East"
-	},
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/machinery/camera/directional/east{
+	c_tag = "Hallway - Central Tram Platform South-East"
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
 "krV" = (
@@ -36852,6 +36879,15 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"lJg" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Left Upper Corridor - Starboard Tram Platform"
+	},
+/turf/open/floor/iron/smooth,
+/area/station/hallway/primary/tram/right)
 "lJm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -44243,6 +44279,13 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/glass/reinforced,
 /area/station/science/genetics)
+"ouh" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/machinery/camera/directional/south{
+	c_tag = "Left Corridor - Central Tram Platform"
+	},
+/turf/open/floor/iron/smooth,
+/area/station/hallway/primary/tram/center)
 "oum" = (
 /obj/machinery/computer/security/qm{
 	dir = 4
@@ -47810,6 +47853,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
+"pJC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Right Upper Corridor - Central Tram Platform"
+	},
+/turf/open/floor/iron/smooth,
+/area/station/hallway/primary/tram/center)
 "pJE" = (
 /obj/structure/chair/comfy/beige{
 	dir = 1
@@ -57603,17 +57658,16 @@
 /turf/open/floor/iron/freezer,
 /area/station/security/prison)
 "tgE" = (
-/obj/machinery/camera{
-	dir = 10;
-	network = list("ss13","medbay");
-	c_tag = "Medical - Central North-West"
-	},
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Medical - Central North-West";
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
@@ -58676,6 +58730,13 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"tzu" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/machinery/camera/directional/south{
+	c_tag = "Right Corridor - Central Tram Platform"
+	},
+/turf/open/floor/iron/smooth,
+/area/station/hallway/primary/tram/center)
 "tzv" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -71437,6 +71498,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
+"xXu" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/machinery/camera/directional/south{
+	c_tag = "Left Corridor - Starboard Tram Platform"
+	},
+/turf/open/floor/iron/smooth,
+/area/station/hallway/primary/tram/right)
 "xXL" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -159062,7 +159130,7 @@ hBf
 pkk
 sDe
 yiM
-aGL
+kho
 ifS
 iPy
 cFs
@@ -159586,7 +159654,7 @@ jGG
 cFs
 iPy
 aGL
-qSQ
+ifi
 yiM
 cFs
 cFs
@@ -166515,7 +166583,7 @@ eSz
 eSz
 eSz
 izU
-clO
+fLw
 xlZ
 nEl
 eSz
@@ -167039,7 +167107,7 @@ lwN
 eSz
 nEl
 ccU
-xlZ
+ouh
 jyH
 pvp
 kSh
@@ -172683,7 +172751,7 @@ aaa
 aaa
 aaa
 izU
-clO
+pJC
 xlZ
 nEl
 eSz
@@ -173207,7 +173275,7 @@ lwN
 eSz
 nEl
 ccU
-xlZ
+tzu
 izU
 wza
 izU
@@ -180146,7 +180214,7 @@ jwH
 brm
 ghV
 gaH
-aHn
+xXu
 lVi
 abM
 soq
@@ -180907,7 +180975,7 @@ jvW
 usY
 usY
 usY
-gaH
+lJg
 mzf
 oGM
 nQY

--- a/_maps/tramstation.json
+++ b/_maps/tramstation.json
@@ -3,7 +3,6 @@
 	"map_name": "Tramstation",
 	"map_path": "map_files/tramstation",
 	"map_file": "tramstation.dmm",
-	"exclude_from_ci": true,
 	"give_players_hooks": 1,
 	"shuttles": {
 		"cargo": "cargo_box",
@@ -11,6 +10,7 @@
 		"whiteship": "whiteship_tram",
 		"emergency": "emergency_tram"
 	},
+	"ignored_unit_tests": ["/datum/unit_test/create_and_destroy"],
 	"traits": [
 		{
 			"Baseturf": "/turf/open/misc/asteroid/airless",


### PR DESCRIPTION

## О изменениях в ПРе
Меняет те самые закрытые аирлоки между станциями на обычные, добавлено больше лестниц на 1 зед левел и обратно

вместе с этим будет снижен минпоп для трама до 5 человек

идея взята с monkestation

<img width="4256" height="416" alt="StrongDMM-2026-07-24 19 21 49" src="https://github.com/user-attachments/assets/7a8e8108-7a86-4393-8327-9c1ddaa82603" />

<img width="4224" height="416" alt="StrongDMM-2026-07-24 19 16 22" src="https://github.com/user-attachments/assets/763d480f-7a52-43ba-b12b-4a609d34fb45" />

## Почему это стоит добавить в игру
## Изменения
:cl: MassMeta
map: Трам теперь более открытый
/:cl:
