### PR TITLE
Initialization text in Lobby 

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -334,7 +334,7 @@ ADMIN_VERB(cmd_controller_view_ui, R_SERVER|R_DEBUG, "Controller Overview", "Vie
 	init_stage_completed = 0
 	var/mc_started = FALSE
 
-	to_chat(world, span_boldannounce("Initializing subsystems..."), MESSAGE_TYPE_DEBUG)
+	//to_chat(world, span_boldannounce("Initializing subsystems..."), MESSAGE_TYPE_DEBUG) MASSMETA REMOVAL
 
 	var/list/stage_sorted_subsystems = new(INITSTAGE_MAX)
 	for (var/i in 1 to INITSTAGE_MAX)
@@ -452,6 +452,12 @@ ADMIN_VERB(cmd_controller_view_ui, R_SERVER|R_DEBUG, "Controller Overview", "Vie
 			// Loop.
 			Master.StartProcessing(0)
 
+	// MASSMETA EDIT
+	var/time = (REALTIMEOFDAY - start_timeofday) / (1 SECONDS)
+	SStitle.total_init_time = time
+	log_world("Initializations complete within [time] second\s!")
+	// MASSMETA EDIT END
+	/* ORIGINAL
 	var/time = (REALTIMEOFDAY - start_timeofday) / 10
 
 
@@ -459,7 +465,7 @@ ADMIN_VERB(cmd_controller_view_ui, R_SERVER|R_DEBUG, "Controller Overview", "Vie
 	var/msg = "Initializations complete within [time] second[time == 1 ? "" : "s"]!"
 	to_chat(world, span_boldannounce("[msg]"), MESSAGE_TYPE_DEBUG)
 	log_world(msg)
-
+	*/
 
 	if(world.system_type == MS_WINDOWS && CONFIG_GET(flag/toast_notification_on_init) && !length(GLOB.clients))
 		world.shelleo("start /min powershell -ExecutionPolicy Bypass -File tools/initToast/initToast.ps1 -name \"[world.name]\" -icon %CD%\\icons\\ui_icons\\common\\tg_16.png -port [world.port]")
@@ -491,7 +497,7 @@ ADMIN_VERB(cmd_controller_view_ui, R_SERVER|R_DEBUG, "Controller Overview", "Vie
 		SS_INIT_NONE,
 		SS_INIT_SUCCESS,
 		SS_INIT_NO_NEED,
-		SS_INIT_NO_MESSAGE,
+		//SS_INIT_NO_MESSAGE, MASSMETA REMOVAL
 	)
 
 	if ((subsystem.ss_flags & SS_NO_INIT) || subsystem.initialized) //Don't init SSs with the corresponding flag or if they already are initialized
@@ -500,6 +506,10 @@ ADMIN_VERB(cmd_controller_view_ui, R_SERVER|R_DEBUG, "Controller Overview", "Vie
 
 	current_initializing_subsystem = subsystem
 	rustg_time_reset(SS_INIT_TIMER_KEY)
+	// MASSMETA ADDITION
+	if(!(subsystem.ss_flags & SS_NO_INIT_MESSAGE))
+		SStitle.add_init_text(subsystem.type, "- [subsystem.name]", "<font color='yellow'>INITIALIZING...</font>")
+	// MASSMETA ADDITION END
 
 	var/result = subsystem.Initialize()
 
@@ -529,22 +539,46 @@ ADMIN_VERB(cmd_controller_view_ui, R_SERVER|R_DEBUG, "Controller Overview", "Vie
 
 	// The rest of this proc is printing the world log and chat message.
 	var/message_prefix
+	// MASSMETA ADDITION
+	var/screen_display = ""
+	var/always_show = FALSE
+	// MASSMETA ADDITION END
 
 	// If true, print the chat message with boldwarning text.
-	var/chat_warning = FALSE
+	//var/chat_warning = FALSE MASSMETA REMOVAL
 
 	switch(result)
 		if(SS_INIT_FAILURE)
 			message_prefix = "Failed to initialize [subsystem.name] subsystem after"
+		// MASSMETA EDIT
+			screen_display = "<font color='red'>FAILED</font>"
+			always_show = TRUE
+		if(SS_INIT_SUCCESS)
+		// MASSMETA EDIT END
+		/* ORIGINAL
 			chat_warning = TRUE
 		if(SS_INIT_SUCCESS, SS_INIT_NO_MESSAGE)
+		*/
 			message_prefix = "Initialized [subsystem.name] subsystem within"
+			screen_display = "<font color='green'>DONE</font>" // MASSMETA ADDITION
 		if(SS_INIT_NO_NEED)
 			// This SS is disabled or is otherwise shy.
-			return
+			pass() // MASSMETA EDIT ORIGINAL: return
 		else
 			// SS_INIT_NONE or an invalid value.
 			message_prefix = "Initialized [subsystem.name] subsystem with errors within"
+	// MASSMETA EDIT
+			screen_display = "<font color='yellow'>ERRORED</font>"
+			always_show = TRUE
+
+	if(screen_display && (always_show || (seconds > 0.1 && !(subsystem.ss_flags & SS_NO_INIT_MESSAGE))))
+		SStitle.add_init_text(subsystem.type, "- [subsystem.name]", screen_display, seconds, major_update = TRUE)
+	else
+		SStitle.remove_init_text(subsystem.type)
+
+	log_world("[message_prefix] [seconds] second\s!")
+	// MASSMETA EDIT END
+	/*
 			chat_warning = TRUE
 
 	var/message = "[message_prefix] [seconds] second[seconds == 1 ? "" : "s"]!"
@@ -553,6 +587,7 @@ ADMIN_VERB(cmd_controller_view_ui, R_SERVER|R_DEBUG, "Controller Overview", "Vie
 	if(result != SS_INIT_NO_MESSAGE)
 		to_chat(world, chat_message, MESSAGE_TYPE_DEBUG)
 	log_world(message)
+	*/
 
 /datum/controller/master/proc/SetRunLevel(new_runlevel)
 	var/old_runlevel = current_runlevel

--- a/code/controllers/subsystem/assets.dm
+++ b/code/controllers/subsystem/assets.dm
@@ -25,8 +25,33 @@ SUBSYSTEM_DEF(assets)
 	transport.Load()
 
 /datum/controller/subsystem/assets/Initialize()
+	// MASSMETA EDIT
+	for(var/datum/asset/asset_type as anything in typesof(/datum/asset))
+		if (asset_type == initial(asset_type.abstract_type))
+			continue
+
+		if (initial(asset_type.early))
+			continue
+
+		var/pre_init = REALTIMEOFDAY
+		var/list/typepath_split = splittext("[asset_type]", "/")
+		var/typepath_readable = capitalize(replacetext(typepath_split[length(typepath_split)], "_", " "))
+
+		SStitle.add_init_text(asset_type, "> [typepath_readable]", "<font color='yellow'>CREATING...</font>")
+		if (load_asset_datum(asset_type))
+			var/time = (REALTIMEOFDAY - pre_init) / (1 SECONDS)
+			if(time <= 0.1)
+				SStitle.remove_init_text(asset_type)
+			else
+				SStitle.add_init_text(asset_type, "> [typepath_readable]", "<font color='green'>DONE</font>", time)
+		else
+			stack_trace("Could not initialize early asset [asset_type]!")
+			SStitle.add_init_text(asset_type, "> [typepath_readable]", "<font color='red'>FAILED</font>")
+	// MASSMETA EDIT END
+	/* ORIGINAL
 	for(var/datum/asset/asset_type as anything in valid_subtypesof(/datum/asset))
 		load_asset_datum(asset_type)
+	*/
 
 	transport.Initialize(cache)
 

--- a/code/controllers/subsystem/early_assets.dm
+++ b/code/controllers/subsystem/early_assets.dm
@@ -24,8 +24,25 @@ SUBSYSTEM_DEF(early_assets)
 		if (!initial(asset_type.early))
 			continue
 
+		// MASSMETA EDIT
+		var/pre_init = REALTIMEOFDAY
+		var/list/typepath_split = splittext("[asset_type]", "/")
+		var/typepath_readable = capitalize(replacetext(typepath_split[length(typepath_split)], "_", " "))
+
+		SStitle.add_init_text(asset_type, "> [typepath_readable]", "<font color='yellow'>CREATING...</font>")
+		if (load_asset_datum(asset_type))
+			var/time = (REALTIMEOFDAY - pre_init) / (1 SECONDS)
+			if(time <= 0.1)
+				SStitle.remove_init_text(asset_type)
+			else
+				SStitle.add_init_text(asset_type, "> [typepath_readable]", "<font color='green'>DONE</font>", time)
+		else
+		//MASSMETA EDIT END
+		/* ORIGINAL
 		if (!load_asset_datum(asset_type))
+		*/
 			stack_trace("Could not initialize early asset [asset_type]!")
+			SStitle.add_init_text(asset_type, "> [typepath_readable]", "<font color='red'>FAILED</font>") // MASSMETA ADDITION
 
 		CHECK_TICK
 

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -131,8 +131,13 @@ SUBSYSTEM_DEF(mapping)
 	require_area_resort()
 	process_teleport_locs() //Sets up the wizard teleport locations
 	preloadTemplates()
+	var/start_time // MASSMETA ADDITION
 
 #ifndef LOWMEMORYMODE
+	// MASSMETA ADDITION
+	start_time = REALTIMEOFDAY
+	SStitle.add_init_text("Empty Space", "> Space", "<font color='yellow'>LOADING...</font>")
+	// MASSMETA ADDITION END
 	// Create space ruin levels
 	while (space_levels_so_far < current_map.space_ruin_levels)
 		add_new_zlevel("Ruin Area [space_levels_so_far+1]", ZTRAITS_SPACE)
@@ -142,6 +147,11 @@ SUBSYSTEM_DEF(mapping)
 	while (space_levels_so_far < current_map.space_empty_levels + current_map.space_ruin_levels)
 		empty_space = add_new_zlevel("Empty Area [space_levels_so_far+1]", list(ZTRAIT_LINKAGE = CROSSLINKED))
 		++space_levels_so_far
+	// MASSMETA ADDITION
+	SStitle.add_init_text("Empty Space", "> Space", "<font color='green'>DONE</font>", (REALTIMEOFDAY - start_time) / (1 SECONDS))
+
+	start_time = REALTIMEOFDAY
+	//MASSMETA ADDITION END
 
 	if(current_map.wilderness_levels)
 		var/list/FailedZs = list()
@@ -153,12 +163,24 @@ SUBSYSTEM_DEF(mapping)
 
 	// Pick a random away mission.
 	if(CONFIG_GET(flag/roundstart_away))
+		SStitle.add_init_text("Away Mission", "> Away Mission", "<font color='yellow'>LOADING...</font>") // MASSMETA ADDITION
 		createRandomZlevel(prob(CONFIG_GET(number/config_gateway_chance)))
+		SStitle.add_init_text("Away Mission", "> Away Mission", "<font color='green'>DONE</font>", (REALTIMEOFDAY - start_time) / (1 SECONDS)) // MASSMETA ADDITION
 
 	else if (SSmapping.current_map.load_all_away_missions) // we're likely in a local testing environment, so punch it.
+		SStitle.add_init_text("Away Mission", "> All Away Missions", "<font color='yellow'>LOADING...</font>") // MASSMETA ADDITION
 		load_all_away_missions()
+	// MASSMETA ADDITION
+		SStitle.add_init_text("Away Mission", "> All Away Missions", "<font color='green'>DONE</font>", (REALTIMEOFDAY - start_time) / (1 SECONDS))
+	else
+		SStitle.add_init_text("Away Mission", "> Away Mission", "<font color='yellow'>SKIPPED</font>")
+
+	start_time = REALTIMEOFDAY
+	SStitle.add_init_text("Ruins", "> Ruins", "<font color='yellow'>LOADING...</font>")
+	// MASSMETA ADDITION END
 
 	setup_ruins()
+	SStitle.add_init_text("Ruins", "> Ruins", "<font color='green'>DONE</font>", (REALTIMEOFDAY - start_time) / (1 SECONDS)) // MASSMETA ADDITION
 #endif
 
 	// Run map generation after ruin space is reserved, since this space is used for the cave gen.
@@ -403,7 +425,10 @@ Used by the AI doomsday and the self-destruct nuke.
 /datum/controller/subsystem/mapping/proc/LoadGroup(list/errorList, name, path, files, list/traits, list/default_traits, silent = FALSE, height_autosetup = TRUE)
 	. = list()
 	var/start_time = REALTIMEOFDAY
-
+	// MASSMETA ADDITION
+	if(!silent)
+		SStitle.add_init_text(path, "> [name]", "<font color='yellow'>LOADING...</font>")
+	//MASSMETA ADDITION END
 	if (!islist(files))  // handle single-level maps
 		files = list(files)
 
@@ -456,7 +481,7 @@ Used by the AI doomsday and the self-destruct nuke.
 		if (!pm.load(x_offset, y_offset, start_z + parsed_maps[P], no_changeturf = TRUE, new_z = TRUE))
 			errorList |= pm.original_path
 	if(!silent)
-		INIT_ANNOUNCE("Loaded [name] in [(REALTIMEOFDAY - start_time)/10]s!")
+		SStitle.add_init_text(path, "> [name]", "<font color='green'>DONE</font>", (REALTIMEOFDAY - start_time) / (1 SECONDS)) // MASSMETA EDIT ORIGINAL: INIT_ANNOUNCE("Loaded [name] in [(REALTIMEOFDAY - start_time)/10]s!")
 	return parsed_maps
 
 /datum/controller/subsystem/mapping/proc/loadWorld()
@@ -468,7 +493,7 @@ Used by the AI doomsday and the self-destruct nuke.
 
 	// load the station
 	station_start = world.maxz + 1
-	INIT_ANNOUNCE("Loading [current_map.map_name]...")
+	//INIT_ANNOUNCE("Loading [current_map.map_name]...") MASSMETA REMOVAL
 	LoadGroup(FailedZs, "Station", current_map.map_path, current_map.map_file, current_map.traits, ZTRAITS_STATION, height_autosetup = current_map.height_autosetup)
 
 	if(SSdbcore.Connect())

--- a/code/controllers/subsystem/radioactive_nebula.dm
+++ b/code/controllers/subsystem/radioactive_nebula.dm
@@ -7,7 +7,7 @@ SUBSYSTEM_DEF(radioactive_nebula)
 	dependencies = list(
 		/datum/controller/subsystem/processing/station,
 	)
-	ss_flags = SS_BACKGROUND
+	ss_flags = SS_BACKGROUND | SS_INIT_NO_MESSAGE // MASSMETA EDIT ORIGINAL: ss_flags = SS_BACKGROUND
 	wait = 30 SECONDS
 
 	VAR_PRIVATE
@@ -31,7 +31,7 @@ SUBSYSTEM_DEF(radioactive_nebula)
 		irradiate_everything()
 
 	// Don't leak that the station trait has been picked
-	return SS_INIT_NO_MESSAGE
+	return SS_INIT_SUCCESS // MASSMETA EDIT ORIGINAL: return SS_INIT_NO_MESSAGE
 
 /// Makes something appear irradiated for the purposes of the Radioactive Nebula
 /datum/controller/subsystem/radioactive_nebula/proc/fake_irradiate(atom/movable/target)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -128,6 +128,7 @@ SUBSYSTEM_DEF(ticker)
 
 			current_state = GAME_STATE_PREGAME
 			SEND_SIGNAL(src, COMSIG_TICKER_ENTER_PREGAME)
+			SStitle.update_init_text() // MASSMETA ADDITION
 			fire()
 		if(GAME_STATE_PREGAME)
 			//lobby stats for statpanels
@@ -158,6 +159,7 @@ SUBSYSTEM_DEF(ticker)
 				SEND_SIGNAL(src, COMSIG_TICKER_ENTER_SETTING_UP)
 				current_state = GAME_STATE_SETTING_UP
 				Master.SetRunLevel(RUNLEVEL_SETUP)
+				SStitle.fade_init_text() // MASSMETA ADDITION
 				if(start_immediately)
 					fire()
 
@@ -352,6 +354,8 @@ SUBSYSTEM_DEF(ticker)
 			to_chat(iter_human, span_notice("You will gain [round(iter_human.hardcore_survival_score) * 2] hardcore random points if you greentext this round!"))
 		else
 			to_chat(iter_human, span_notice("You will gain [round(iter_human.hardcore_survival_score)] hardcore random points if you survive this round!"))
+
+		SStitle.update_init_text() // MASSMETA ADDITION
 
 /datum/controller/subsystem/ticker/proc/display_roundstart_logout_report()
 	var/list/msg = list("[span_boldnotice("Roundstart logout report")]\n\n")

--- a/code/controllers/subsystem/title.dm
+++ b/code/controllers/subsystem/title.dm
@@ -6,6 +6,17 @@ SUBSYSTEM_DEF(title)
 	var/icon/icon
 	var/icon/previous_icon
 	var/turf/closed/indestructible/splashscreen/splash_turf
+	// MASSMETA ADDITION
+	/// A holder for maptext that displays initialization information on the title screen
+	var/obj/effect/abstract/init_order_holder/maptext_holder
+
+	/// A list of initialization information
+	var/list/init_infos = list()
+	/// Tracks the number of dots to display
+	var/num_dots = 1
+	/// The total time taken to initialize the game
+	var/total_init_time = -1
+	// MASSMETA ADDITION END
 
 /datum/controller/subsystem/title/Initialize()
 	if(file_path && icon)
@@ -66,3 +77,122 @@ SUBSYSTEM_DEF(title)
 	splash_turf = SStitle.splash_turf
 	file_path = SStitle.file_path
 	previous_icon = SStitle.previous_icon
+// MASSMETA ADDITION
+	init_infos = SStitle.init_infos
+
+#define MAX_INIT_TEXT 40
+
+/**
+ * Adds an entry to the initialization information list
+ *
+ * * init_category: The category of the initialization information - this must be a unique key, such as a typepath.
+ * Tt's not displayed to the player, so don't worry about making it pretty.
+ * * name: The name of the initialization information. This is displayed to the player.
+ * * stage: The "stage" of the initialization information, such as "loading" / "complete" / "failed".
+ * * seconds: The number of seconds this initialization information took. Optional.
+ * * override: If TRUE, this will overwrite any existing entry with the same init_category.
+ * Othewise, it will try to update the existing entry's state and time.
+ * * major_update: Indicates this init text is a major update, which will update a "dot" animation.
+ */
+/datum/controller/subsystem/title/proc/add_init_text(init_category, name, stage, seconds, override = FALSE, major_update = FALSE)
+	if(override || !init_infos[init_category])
+		init_infos[init_category] = list(name, stage, seconds)
+	else
+		init_infos[init_category][2] = stage
+		init_infos[init_category][3] += seconds
+	if(major_update)
+		num_dots = (num_dots % 6 + 1)
+	if(length(init_infos) > MAX_INIT_TEXT)
+		init_infos.Cut(1, length(init_infos) - MAX_INIT_TEXT + 1)
+	update_init_text()
+
+#undef MAX_INIT_TEXT
+
+/// Removes the passed category from the initialization information list
+/datum/controller/subsystem/title/proc/remove_init_text(init_category)
+	init_infos -= init_category
+	update_init_text()
+
+/// Updates the displayed initialization text according to all initialization information, unless the round has started,
+/// at which point you don't need anymore information anymore.
+/datum/controller/subsystem/title/proc/update_init_text()
+	if(SSticker.HasRoundStarted())
+		if(maptext_holder)
+			maptext_holder.maptext = null
+		return
+
+	if(!maptext_holder)
+		if(!splash_turf)
+			return
+		maptext_holder = new(splash_turf)
+
+	maptext_holder.maptext = "<span class='maptext' style='font-size: 6px;'>"
+	maptext_holder.maptext += "<span class='big' style='font-size: 12px;'>"
+	if(SSticker?.current_state == GAME_STATE_PREGAME)
+		var/total_time_formatted = "[total_init_time]s"
+		switch(total_init_time)
+			if(0 to 60)
+				total_time_formatted = "<font color='green'>[total_init_time]s</font>"
+			if(60 to 120)
+				total_time_formatted = "<font color='yellow'>[total_init_time]s</font>"
+			if(120 to INFINITY)
+				total_time_formatted = "<font color='red'>[total_init_time]s</font>"
+
+		maptext_holder.maptext += "Initialized (in [total_time_formatted])"
+	else
+		maptext_holder.maptext += "Initializing game"
+		for(var/i in 1 to num_dots)
+			maptext_holder.maptext += "."
+	maptext_holder.maptext += "</span><br>"
+	for(var/sstype in init_infos)
+		var/list/init_data = init_infos[sstype]
+		var/init_name = init_data[1]
+		var/init_stage = init_data[2]
+		var/init_time = isnum(init_data[3]) ? "([init_data[3]]s)" : ""
+		maptext_holder.maptext += "<br>[init_name] [init_stage] [init_time]"
+	maptext_holder.maptext += "<br></span>"
+
+/// Simply fades out the initialization text
+/datum/controller/subsystem/title/proc/fade_init_text()
+	update_init_text()
+	animate(maptext_holder, alpha = 0, time = 3 SECONDS)
+
+/// Abstract holder for maptext on the lobby screen
+/obj/effect/abstract/init_order_holder
+	icon = null
+	icon_state = null
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	maptext_height = 500
+	maptext_width = 200
+	maptext_x = 12
+	maptext_y = 12
+	plane = SPLASHSCREEN_PLANE
+	pixel_x = -64
+	/// Conceals the holder from clients who don't want to see it
+	var/image/hide_me
+
+/obj/effect/abstract/init_order_holder/Initialize(mapload)
+	. = ..()
+	for(var/mob/dead/new_player/lobby_goer as anything in GLOB.new_player_list)
+		check_client(lobby_goer.client)
+
+/// Check if the client should see or should not see the initialization information. Updates accordingly.
+/obj/effect/abstract/init_order_holder/proc/check_client(client/seer)
+	if(isnull(seer))
+		return
+	if(!seer.prefs.read_preference(/datum/preference/toggle/show_init_stats))
+		hide_from_client(seer)
+		return
+	show_to_client(seer)
+
+/// Hides the initialization information from the client
+/obj/effect/abstract/init_order_holder/proc/hide_from_client(client/seer)
+	if(isnull(hide_me))
+		hide_me = image(loc = src)
+		hide_me.override = TRUE
+	seer?.images |= hide_me
+
+/// Shows the initialization information to the client (if already hidden, otherwise nothing happens)
+/obj/effect/abstract/init_order_holder/proc/show_to_client(client/seer)
+	seer?.images -= hide_me
+// MASSMETA ADDITION END

--- a/code/datums/mapgen/CaveGenerator.dm
+++ b/code/datums/mapgen/CaveGenerator.dm
@@ -154,7 +154,7 @@
 		return generate_terrain_with_biomes(turfs, generate_in)
 
 	var/start_time = REALTIMEOFDAY
-
+	SStitle.add_init_text("[type]gen", "> [name]: Generation", "<font color='yellow'>LOADING</font>") // MASSMETA ADDITION
 	string_gen = generate_cave(generate_in)
 
 	for(var/turf/gen_turf as anything in turfs) //Go through all the turfs and generate them
@@ -168,10 +168,15 @@
 		if(gen_turf.turf_flags & NO_RUINS)
 			new_turf.turf_flags |= NO_RUINS
 
+	// MASSMETA EDIT
+	SStitle.add_init_text("[type]gen", "> [name]: Generation", "<font color='green'>DONE</font>", (REALTIMEOFDAY - start_time) / (1 SECONDS))
+	log_world("[name] terrain generation finished in [(REALTIMEOFDAY - start_time)/10]s!")
+	// MASSMETA EDIT END
+	/* ORIGINAL
 	var/message = "[name] terrain generation finished in [(REALTIMEOFDAY - start_time)/10]s!"
 	to_chat(world, span_boldannounce("[message]"), MESSAGE_TYPE_DEBUG)
 	log_world(message)
-
+	*/
 
 /**
  * This proc handles including biomes in the cave generation. This is slower than
@@ -206,6 +211,7 @@
 		humidity_seed = rand(0, 50000)
 		heat_seed = rand(0, 50000)
 
+	SStitle.add_init_text("[type]fill", "> [name]: Population", "<font color='yellow'>LOADING</font>") // MASSMETA ADDITION
 	var/start_time = REALTIMEOFDAY
 	string_gen = generate_cave(generate_in)
 
@@ -258,9 +264,15 @@
 			generated_turfs_per_area_biome[biome] = area_list
 		area_list[generate_in] = generated_turfs
 
+	// MASSMETA EDIT
+	SStitle.add_init_text("[type]fill", "> [name]: Population", "<font color='green'>DONE</font>", (REALTIMEOFDAY - start_time) / (1 SECONDS))
+	log_world("[name] terrain population finished in [(REALTIMEOFDAY - start_time)/10]s!")
+	// MASSMETA EDIT END
+	/* ORIGINAL
 	var/message = "[name] terrain generation finished in [(REALTIMEOFDAY - start_time)/10]s!"
 	to_chat(world, span_boldannounce("[message]"), MESSAGE_TYPE_DEBUG)
 	log_world(message)
+	*/
 
 /// Returns a biome datum that the turf was initialized with, or would be if it is present on our Z level and we use a consistent shared seed
 /// Not consistent between calls by itself due to using RNG in perlin zoom, needs a static coordinate-based formula
@@ -418,9 +430,15 @@
 
 		CHECK_TICK
 
+	// MASSMETA EDIT
+	SStitle.add_init_text("[type]fill", "> [name]: Population", "<font color='green'>DONE</font>", (REALTIMEOFDAY - start_time) / (1 SECONDS))
+	log_world("[name] terrain population finished in [(REALTIMEOFDAY - start_time)/10]s!")
+	// MASSMETA EDIT END
+	/* ORIGINAL
 	var/message = "[name] terrain population finished in [(REALTIMEOFDAY - start_time)/10]s!"
 	to_chat(world, span_boldannounce("[message]"), MESSAGE_TYPE_DEBUG)
 	log_world(message)
+	*/
 
 
 ///Generates the cave shape using Rust-G

--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -53,6 +53,7 @@
 		return
 
 	if(SSticker.current_state < GAME_STATE_SETTING_UP)
+		SStitle?.maptext_holder?.check_client(client) // MASSMETA ADDITION
 		var/tl = SSticker.GetTimeLeft()
 		to_chat(src, "Please set up your character and select \"Ready\". The game will start [tl > 0 ? "in about [DisplayTimeText(tl)]" : "soon"].")
 

--- a/modular_meta/_defines/_main_modular_defines_include.dm
+++ b/modular_meta/_defines/_main_modular_defines_include.dm
@@ -6,5 +6,6 @@
 #include "re_hooch_heals_assistants.dm"
 #include "justice_mecha.dm"
 #include "techweb_nodes.dm"
+#include "mc.dm"
 #include "mentors.dm"
 #include "signals_traitor.dm"

--- a/modular_meta/_defines/mc.dm
+++ b/modular_meta/_defines/mc.dm
@@ -1,0 +1,1 @@
+#define SS_NO_INIT_MESSAGE (1 << 8)

--- a/modular_meta/main_modular_include.dm
+++ b/modular_meta/main_modular_include.dm
@@ -87,3 +87,4 @@
 #include "tweaks\simple_vote_by_default\includes.dm"
 #include "tweaks\runtimes_fix\includes.dm"
 #include "tweaks\metacoins_to_homepage\includes.dm"
+#include "tweaks\init_text\includes.dm"

--- a/modular_meta/tweaks/init_text/README.md
+++ b/modular_meta/tweaks/init_text/README.md
@@ -2,7 +2,7 @@
 
 ### Defines/Helpers:
 
-- modular_meta/\_defines/mc.dm
+- modular_meta/_defines/mc.dm
 
 ### TG Proc/File Changes:
 

--- a/modular_meta/tweaks/init_text/README.md
+++ b/modular_meta/tweaks/init_text/README.md
@@ -1,0 +1,25 @@
+## Module ID: init_text
+
+### Defines/Helpers:
+
+- modular_meta/\_defines/mc.dm
+
+### TG Proc/File Changes:
+
+- code/controllers/subsystem/assets.dm
+- code/controllers/subsystem/early_assets.dm
+- code/controllers/subsystem/mapping.dm
+- code/controllers/subsystem/radioactive_nebula.dm
+- code/controllers/subsystem/ticker.dm
+- code/controllers/subsystem/title.dm
+- code/controllers/master.dm
+- code/datums/mapgen/CaveGenerator.dm
+- code/modules/mob/dead/new_player/login.dm
+
+### TGUI Files:
+
+- tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/init_stats.tsx
+
+### Ported from:
+
+- github.com/MrMelbert/MapleStationCode

--- a/modular_meta/tweaks/init_text/code.dm
+++ b/modular_meta/tweaks/init_text/code.dm
@@ -1,0 +1,9 @@
+/datum/preference/toggle/show_init_stats
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "show_init_stats"
+	savefile_identifier = PREFERENCE_PLAYER
+	default_value = TRUE
+
+/datum/preference/toggle/show_init_stats/apply_to_client_updated(client/client, value)
+	if(isnewplayer(client.mob))
+		SStitle?.maptext_holder?.check_client(client)

--- a/modular_meta/tweaks/init_text/includes.dm
+++ b/modular_meta/tweaks/init_text/includes.dm
@@ -1,0 +1,8 @@
+#include "code.dm"
+
+/datum/modpack/init_text
+	id = "init_text"
+	name = "Init Text on Screen"
+	group = "Features"
+	desc = "Текст инициализации теперь на экране лобби"
+	author = "Glamyr"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/init_stats.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/init_stats.tsx
@@ -1,0 +1,9 @@
+import { CheckboxInput, type FeatureToggle } from '../base';
+
+export const show_init_stats: FeatureToggle = {
+  name: 'Enable Lobby Game Stats',
+  category: 'UI',
+  description:
+    'When enabled, the lobby screen will report how long game set up is taking.',
+  component: CheckboxInput,
+};


### PR DESCRIPTION

## О изменениях в ПРе
взято из github.com/MrMelbert/MapleStationCode. Добавляет в лобби текст инициализации, да да как на монкестейшен, выглядит оно так: 

<img width="470" height="734" alt="image" src="https://github.com/user-attachments/assets/952b1d5d-c15b-4de9-aafb-e2c5baadbca9" />

а затем пропадает после того как раунд начался, можно убрать зайдя в настройки > UI > Enable Lobby Game Stats
## Почему это стоит добавить в игру
## Изменения
:cl: MassMeta
madd: Визуализация инициализации теперь выводится как внутриигровой текст в лобби, вместо текста в чате. Можно скрыть в настройках.
/:cl:
