### PR TITLE
feature: adds self-surgery chip to persistent mcoin shop

### DIFF
--- a/modular_meta/features/metacoins/code/persistent.dm
+++ b/modular_meta/features/metacoins/code/persistent.dm
@@ -18,7 +18,7 @@ To check if a reward is bought
 		id = "perm_surg"
 		name = "4U70-P3R4710N skillchip"
 		desc = "This investment will allow you to cut your self open (without much harm)"
-		price = 4870
+		price = 8704
 		listing_type = "persistent"
 		item_type = /obj/item/skillchip/self_surgery
 

--- a/modular_meta/features/metacoins/code/persistent.dm
+++ b/modular_meta/features/metacoins/code/persistent.dm
@@ -17,7 +17,7 @@ To check if a reward is bought
 /datum/metacoinshop/listing/persistent/perm_surg
 		id = "perm_surg"
 		name = "4U70-P3R4710N skillchip"
-		desc = "This investment will allow you to cut your self open (without much harm)"
+		desc = "Auto-surgery skillchip, for your daily self-cutting needs!"
 		price = 8704
 		listing_type = "persistent"
 		item_type = /obj/item/skillchip/self_surgery

--- a/modular_meta/features/metacoins/code/persistent.dm
+++ b/modular_meta/features/metacoins/code/persistent.dm
@@ -17,7 +17,7 @@ To check if a reward is bought
 /datum/metacoinshop/listing/persistent/perm_surg
 		id = "perm_surg"
 		name = "4U70-P3R4710N skillchip"
-		desc = "Auto-surgery skillchip, for your daily self-cutting needs!"
+		desc = "Self-surgery skillchip, for your daily self-cutting needs!"
 		price = 8704
 		listing_type = "persistent"
 		item_type = /obj/item/skillchip/self_surgery

--- a/modular_meta/features/metacoins/code/persistent.dm
+++ b/modular_meta/features/metacoins/code/persistent.dm
@@ -22,6 +22,12 @@ To check if a reward is bought
 		listing_type = "persistent"
 		item_type = /obj/item/skillchip/self_surgery
 
+/datum/metacoinshop/listing/persistent/perm_surg/persistent_grant(datum/metacoin_shop_controller/shop, target_ckey, mob/living/spawned, client/player_client)
+	var/obj/item/skillchip/skillchip = new item_type()
+	var/mob/living/carbon/human/patient = spawned
+	patient.implant_skillchip(skillchip)
+	skillchip.try_activate_skillchip()
+
 // DO NOT CHANGE ID'S, DOING SO WILL RESULT A DUPLICATE IN DB
 /datum/metacoinshop/listing/persistent/wycc_soul
 	id = "wycc_soul"

--- a/modular_meta/features/metacoins/code/persistent.dm
+++ b/modular_meta/features/metacoins/code/persistent.dm
@@ -14,6 +14,14 @@ To check if a reward is bought
 		// you can lock anything behind it, unique reskins? job titles? jobs? like be able to spawn as an NT official? anything whatsoever!
 */
 
+/datum/metacoinshop/listing/persistent/perm_surg
+		id = "perm_surg"
+		name = "4U70-P3R4710N skillchip"
+		desc = "This investment will allow you to cut your self open (without much harm)"
+		price = 4870
+		listing_type = "persistent"
+		item_type = /obj/item/skillchip/self_surgery
+
 // DO NOT CHANGE ID'S, DOING SO WILL RESULT A DUPLICATE IN DB
 /datum/metacoinshop/listing/persistent/wycc_soul
 	id = "wycc_soul"

--- a/modular_meta/features/metacoins/readme.md
+++ b/modular_meta/features/metacoins/readme.md
@@ -2,8 +2,6 @@
 
 ### Description:
 
-Here you do things with your money
-
 ### TG Proc/File Changes:
 
 code\datums\achievements_awards.dm - 94 - 99 - every achievement gives you some coins!
@@ -14,8 +12,6 @@ code\modules\deathmatch\deathmatch_controller.dm -
 ### Modular Overrides:
 
 TODO:
-
-- THE THINGS
 
 ### Defines:
 

--- a/modular_meta/features/metacoins/readme.md
+++ b/modular_meta/features/metacoins/readme.md
@@ -2,6 +2,8 @@
 
 ### Description:
 
+Here you do things with your money
+
 ### TG Proc/File Changes:
 
 code\datums\achievements_awards.dm - 94 - 99 - every achievement gives you some coins!
@@ -12,6 +14,8 @@ code\modules\deathmatch\deathmatch_controller.dm -
 ### Modular Overrides:
 
 TODO:
+
+- THE THINGS
 
 ### Defines:
 


### PR DESCRIPTION

## О изменениях в ПРе

### Попытка добавить постоянный предмет за МетаКоины (СюрджеонЧип)

## Почему это стоит добавить в игру

<details>
<summary>🔪💀</summary>
<img width="396" height="498" alt="LobotomyCat" src="https://github.com/user-attachments/assets/aade70d2-bf2a-469d-a489-0d1bbc4b7d57" />
</details>

### Купил 1 раз и не придётся оплачивать подписку на чип
## Изменения
:cl: qqq213
madd: Добавляет Self-Surg-Чип в статичный магазин
/:cl: